### PR TITLE
Modbus service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ buildDeb {
     configurationFile("${pkgInstallFolder}/conf/mqtt-config.json")
     configurationFile("${pkgInstallFolder}/conf/opc-config.json")
     configurationFile("${pkgInstallFolder}/conf/http-config.json")
+    configurationFile("${pkgInstallFolder}/conf/modbus-config.json")
 
     preInstall file("${buildDir}/control/deb/preinst")
     postInstall file("${buildDir}/control/deb/postinst")

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <bouncycastle.version>1.52</bouncycastle.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.1.7</logback.version>
+        <j2mod.version>2.4.1</j2mod.version>
         <pkg.name>tb-gateway</pkg.name>
         <pkg.user>thingsboard</pkg.user>
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
@@ -152,6 +153,11 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ghgande</groupId>
+            <artifactId>j2mod</artifactId>
+            <version>${j2mod.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/DefaultModbusService.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/DefaultModbusService.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.gateway.extensions.modbus;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.thingsboard.gateway.extensions.ExtensionUpdate;
+import org.thingsboard.gateway.service.conf.TbExtensionConfiguration;
+import org.thingsboard.gateway.service.gateway.GatewayService;
+import org.thingsboard.gateway.util.ConfigurationTools;
+
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusConfiguration;
+
+@Slf4j
+public class DefaultModbusService extends ExtensionUpdate implements ModbusService {
+
+    private final GatewayService gateway;
+    private TbExtensionConfiguration currentConfiguration;
+    private List<ModbusClient> clients;
+
+    public DefaultModbusService(GatewayService gateway) {
+        this.gateway = gateway;
+    }
+
+    public TbExtensionConfiguration getCurrentConfiguration() {
+        return currentConfiguration;
+    }
+
+    public void init(TbExtensionConfiguration configurationNode, Boolean isRemote) throws Exception {
+        currentConfiguration = configurationNode;
+        log.info("[{}] Initializing Modbus service", gateway.getTenantLabel());
+        ModbusConfiguration configuration;
+        try {
+            if(isRemote) {
+                configuration = ConfigurationTools.readConfiguration(configurationNode.getConfiguration(), ModbusConfiguration.class);
+            } else {
+                configuration = ConfigurationTools.readFileConfiguration(configurationNode.getExtensionConfiguration(), ModbusConfiguration.class);
+            }
+        } catch (Exception e) {
+            log.error("[{}] Modbus service configuration failed", gateway.getTenantLabel(), e);
+            gateway.onConfigurationError(e, currentConfiguration);
+            throw e;
+        }
+
+        log.debug("[{}] Modbus service configuration [{}]", gateway.getTenantLabel(), configuration);
+
+        try {
+            clients = configuration.getServers().stream().map(c -> new ModbusClient(gateway, c)).collect(Collectors.toList());
+            clients.forEach(ModbusClient::connect);
+        } catch (Exception e) {
+            log.error("[{}] Modbus service initialization failed", gateway.getTenantLabel(), e);
+            gateway.onConfigurationError(e, currentConfiguration);
+            throw e;
+        }
+    }
+
+    public void destroy() {
+        if (clients != null) {
+            clients.forEach(ModbusClient::disconnect);
+        }
+    }
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusClient.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusClient.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.gateway.extensions.modbus;
+
+import com.ghgande.j2mod.modbus.Modbus;
+import com.ghgande.j2mod.modbus.ModbusException;
+import com.ghgande.j2mod.modbus.facade.AbstractModbusMaster;
+import com.ghgande.j2mod.modbus.facade.ModbusSerialMaster;
+import com.ghgande.j2mod.modbus.facade.ModbusTCPMaster;
+import com.ghgande.j2mod.modbus.facade.ModbusUDPMaster;
+import com.ghgande.j2mod.modbus.io.ModbusTransaction;
+import com.ghgande.j2mod.modbus.msg.*;
+import com.ghgande.j2mod.modbus.util.SerialParameters;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusServerConfiguration;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.TagMapping;
+import org.thingsboard.gateway.extensions.modbus.conf.transport.*;
+import org.thingsboard.gateway.service.gateway.GatewayService;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ModbusClient {
+
+    private GatewayService gateway;
+    private ModbusServerConfiguration configuration;
+
+    private AbstractModbusMaster client;
+    private ModbusTransaction transaction;
+    private String serverName;
+
+    private List<ModbusDevice> devices;
+
+    private ScheduledExecutorService executor;
+
+    public ModbusClient(GatewayService gateway, ModbusServerConfiguration configuration) {
+        this.gateway = gateway;
+        this.configuration = configuration;
+        this.client = createClient(this.configuration.getTransport());
+        this.executor = Executors.newSingleThreadScheduledExecutor();
+        this.devices = this.configuration.getDevices().stream().map(conf -> new ModbusDevice(conf)).collect(Collectors.toList());
+        this.serverName = createServerName(this.configuration.getTransport());
+    }
+
+    private String createServerName(ModbusTransportConfiguration configuration) {
+        if (configuration instanceof ModbusIpTransportConfiguration) {
+            ModbusIpTransportConfiguration ipConf = (ModbusIpTransportConfiguration) configuration;
+            return ipConf.getHost() + ":" + ipConf.getPort();
+        } else if (configuration instanceof ModbusRtuTransportConfiguration) {
+            return ((ModbusRtuTransportConfiguration) configuration).getPortName();
+        }
+
+        throw new IllegalArgumentException("Unknown Modbus transport " + configuration.getClass().toString());
+    }
+
+    private AbstractModbusMaster createClient(ModbusTransportConfiguration configuration) {
+        if (configuration instanceof ModbusTcpTransportConfiguration) {
+            ModbusTcpTransportConfiguration tcpConf = (ModbusTcpTransportConfiguration) configuration;
+            log.trace("Creating TCP Modbus client [{}]", tcpConf);
+            return new ModbusTCPMaster(tcpConf.getHost(),
+                                       tcpConf.getPort(),
+                                       tcpConf.getTimeout(),
+                                       false);
+        } else if (configuration instanceof ModbusUdpTransportConfiguration) {
+            ModbusUdpTransportConfiguration udpConf = (ModbusUdpTransportConfiguration) configuration;
+            log.trace("Creating UDP Modbus client [{}]", udpConf);
+            return new ModbusUDPMaster(udpConf.getHost(),
+                                       udpConf.getPort(),
+                                       udpConf.getTimeout());
+        } else if (configuration instanceof ModbusRtuTransportConfiguration) {
+            ModbusRtuTransportConfiguration rtuConf = (ModbusRtuTransportConfiguration) configuration;
+            SerialParameters serialParams = new SerialParameters();
+            serialParams.setPortName(rtuConf.getPortName());
+            serialParams.setBaudRate(rtuConf.getBaudRate());
+            serialParams.setDatabits(Integer.toString(rtuConf.getDataBits())); // cast to string due to range validation while parsing
+            serialParams.setStopbits(Float.toString(rtuConf.getStopBits())); // cast to string due to range validation while parsing
+            serialParams.setParity(rtuConf.getParity());
+            serialParams.setEncoding(rtuConf.getEncoding());
+
+            log.trace("Creating RTU Modbus client [{}]", rtuConf);
+            return new ModbusSerialMaster(serialParams, rtuConf.getTimeout());
+        } else {
+            log.error("[{}] Unknown Modbus transport configuration {}", gateway.getTenantLabel(), configuration);
+            throw new IllegalArgumentException("Unknown Modbus transport configuration");
+        }
+    }
+
+    public void connect() {
+        try {
+            log.trace("MBS[{}] connecting...", serverName);
+
+            client.connect();
+            transaction = client.getTransport().createTransaction();
+
+            log.info("MBS[{}] connected", serverName);
+
+            firstRead();
+            startPolling();
+        } catch (Exception e) {
+            log.error("MBS[{}] connection failed!", serverName, e);
+            throw new RuntimeException("MBS connection failed!", e);
+        }
+    }
+
+    private void firstRead() {
+        log.info("MBS[{}] going to first read", serverName);
+
+        devices.stream().forEach(device -> {
+            readTags(device, device.getAttributesMappings());
+            readTags(device, device.getTimeseriesMappings());
+
+            gateway.onDeviceConnect(device.getName(), null);
+
+            log.info("MBS[{}] connected new MBD[{}]", serverName, device.getName());
+
+            checkDeviceDataUpdates(device);
+        });
+    }
+
+    private void startPolling() {
+        log.info("Start polling MBS[{}]", serverName);
+
+        devices.stream().forEach(device -> {
+            device.getSortedTagMappings().entrySet().stream().forEach(tags -> {
+                log.info("MBS[{}] Schedule polling [{}] slave for tag(s) [{}], period {} ms",
+                        serverName,
+                        device.getName(),
+                        tags.getValue().stream().map(t -> t.getTag()).collect(Collectors.joining(",")),
+                        tags.getKey());
+
+                executor.scheduleAtFixedRate(()->{
+                    device.clearUpdates();
+                    readTags(device, tags.getValue());
+                    checkDeviceDataUpdates(device);
+                },
+                tags.getKey(), tags.getKey(), TimeUnit.MILLISECONDS);
+            });
+        });
+    }
+
+    private void checkDeviceDataUpdates(ModbusDevice device) {
+        if (!device.getAttributesUpdate().isEmpty()) {
+            gateway.onDeviceAttributesUpdate(device.getName(), device.getAttributesUpdate());
+        }
+        if (!device.getTimeseriesUpdate().isEmpty()) {
+            gateway.onDeviceTelemetry(device.getName(), device.getTimeseriesUpdate());
+        }
+    }
+
+    private void readTags(ModbusDevice device, List<TagMapping> mappings) {
+        mappings.stream().forEach(m -> readTag(device, m));
+    }
+
+    private void readTag(ModbusDevice device, TagMapping mapping) {
+        ModbusRequest request = createRequest(device, mapping);
+        transaction.setRequest(request);
+        try {
+            transaction.execute();
+            processResponse(transaction.getResponse(), device, mapping);
+        } catch (ModbusException e) {
+            log.error("MBS[{}] failed to read from MBD[{}], tag [{}]", serverName, device.getName(), mapping.getTag(), e);
+        }
+    }
+
+    private ModbusRequest createRequest(ModbusDevice device, TagMapping mapping) {
+        ModbusRequest request = null;
+
+        switch (mapping.getFunctionCode()) {
+            case Modbus.READ_COILS:
+                request = new ReadCoilsRequest(mapping.getAddress(), ModbusExtensionConstants.DEFAULT_REGISTER_COUNT_FOR_BOOLEAN);
+                break;
+            case Modbus.READ_INPUT_DISCRETES:
+                request = new ReadInputDiscretesRequest(mapping.getAddress(), ModbusExtensionConstants.DEFAULT_REGISTER_COUNT_FOR_BOOLEAN);
+                break;
+            case Modbus.READ_INPUT_REGISTERS:
+                request = new ReadInputRegistersRequest(mapping.getAddress(), mapping.getRegisterCount());
+                break;
+            case Modbus.READ_HOLDING_REGISTERS:
+                request = new ReadMultipleRegistersRequest(mapping.getAddress(), mapping.getRegisterCount());
+                break;
+            default:
+                log.error("MBS[{}] function {} is not supported: MBD[{}], tag [{}]",
+                        serverName, mapping.getFunctionCode(), device.getName(), mapping.getTag());
+                throw new IllegalArgumentException("Unsupported Modbus function " + mapping.getFunctionCode());
+        }
+
+        request.setUnitID(device.getUnitId());
+
+        return request;
+    }
+
+    private void processResponse(ModbusResponse response, ModbusDevice device, TagMapping mapping) {
+        switch (mapping.getFunctionCode()) {
+            case Modbus.READ_COILS:
+                ReadCoilsResponse rcResp = (ReadCoilsResponse) response;
+                device.updateTag(mapping, rcResp.getCoils());
+                break;
+            case Modbus.READ_INPUT_DISCRETES:
+                ReadInputDiscretesResponse ridResp = (ReadInputDiscretesResponse) response;
+                device.updateTag(mapping, ridResp.getDiscretes());
+                break;
+            case Modbus.READ_INPUT_REGISTERS:
+                ReadInputRegistersResponse rirResp = (ReadInputRegistersResponse) response;
+                device.updateTag(mapping, rirResp.getRegisters());
+                break;
+            case Modbus.READ_HOLDING_REGISTERS:
+                ReadMultipleRegistersResponse rmrResp = (ReadMultipleRegistersResponse) response;
+                device.updateTag(mapping, rmrResp.getRegisters());
+                break;
+            default:
+                log.error("MBS[{}] function {} is not supported: MBD[{}], tag [{}]",
+                        serverName, mapping.getFunctionCode(), device.getName(), mapping.getTag());
+                throw new IllegalArgumentException("Unsupported Modbus function " + mapping.getFunctionCode());
+        }
+    }
+
+    public void disconnect() {
+        executor.shutdownNow();
+
+        log.trace("Disconnecting from MBS[{}]", serverName);
+        client.disconnect();
+        log.info("Disconnected from MBS[{}]", serverName);
+
+        devices.stream().forEach((d)->{
+                gateway.onDeviceDisconnect(d.getName());
+                log.info("MBS[{}] disconnected MBD[{}]", serverName, d.getName());
+        });
+    }
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusDevice.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusDevice.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thingsboard.gateway.extensions.modbus;
+
+import com.ghgande.j2mod.modbus.ModbusException;
+import com.ghgande.j2mod.modbus.procimg.InputRegister;
+import com.ghgande.j2mod.modbus.util.BitVector;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.DeviceMapping;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.TagMapping;
+import org.thingsboard.server.common.data.kv.*;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.CharBuffer;
+import java.nio.LongBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Slf4j
+public class ModbusDevice {
+    private DeviceMapping configuration;
+
+    private Map<Integer, List<TagMapping>> tagsByPollPeriod = new HashMap<>();
+
+    private Map<String, KvEntry> attributes = new HashMap<>();
+    private Map<String, TsKvEntry> timeseries = new HashMap<>();
+
+    private List<KvEntry> attributesUpdates = new LinkedList<>();
+    private List<TsKvEntry> timeseriesUpdates = new LinkedList<>();
+
+    public ModbusDevice(DeviceMapping conf) {
+        this.configuration = conf;
+
+        sortByPollPeriod(configuration.getAttributes(), configuration.getAttributesPollPeriod());
+        sortByPollPeriod(configuration.getTimeseries(), configuration.getTimeseriesPollPeriod());
+
+        configuration.getAttributes().stream().forEach(attr -> attributes.put(attr.getTag(), null));
+    }
+
+    private void sortByPollPeriod(List<TagMapping> mappings, int defaultPollPeriod) {
+        mappings.stream().forEach(m -> {
+            int pollPeriod = m.getPollPeriod();
+            if (pollPeriod == ModbusExtensionConstants.NO_POLL_PERIOD_DEFINED) {
+                pollPeriod = defaultPollPeriod;
+            }
+
+            tagsByPollPeriod.computeIfAbsent(pollPeriod, (k) -> new LinkedList<>()).add(m);
+        });
+    }
+
+    public int getUnitId() {
+        return configuration.getUnitId();
+    }
+
+    public String getName() {
+        return configuration.getDeviceName();
+    }
+
+    public Map<Integer, List<TagMapping>> getSortedTagMappings() {
+        return tagsByPollPeriod;
+    }
+
+    public void updateTag(TagMapping mapping, BitVector data) {
+        updateTag(mapping, convertToDataEntry(mapping, data.getBit(ModbusExtensionConstants.DEFAULT_BIT_INDEX_FOR_BOOLEAN)));
+    }
+
+    public void updateTag(TagMapping mapping, InputRegister[] data) {
+        updateTag(mapping, convertToDataEntry(mapping, data));
+    }
+
+    private void updateTag(TagMapping mapping, KvEntry entry) {
+        if (attributes.containsKey(mapping.getTag())) {
+            KvEntry oldEntry = attributes.get(mapping.getTag());
+            if (oldEntry == null || !oldEntry.getValue().equals(entry.getValue())) {
+                attributes.put(mapping.getTag(), entry);
+                attributesUpdates.add(entry);
+
+                log.debug("MBD[{}] attribute update: key '{}', val '{}'", configuration.getDeviceName(), entry.getKey(), entry.getValue());
+            }
+        } else {
+            TsKvEntry oldEntry = timeseries.get(mapping.getTag());
+            if (oldEntry == null || !oldEntry.getValue().equals(entry.getValue())) {
+                TsKvEntry newTsEntry = new BasicTsKvEntry(System.currentTimeMillis(), entry);
+                timeseries.put(mapping.getTag(), newTsEntry);
+                timeseriesUpdates.add(newTsEntry);
+
+                log.debug("MBD[{}] timeseries update:  key '{}', val '{}'", configuration.getDeviceName(), entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    private KvEntry convertToDataEntry(TagMapping mapping, boolean value) {
+        KvEntry entry = null;
+
+        switch (mapping.getType().getDataType()) {
+            case STRING:
+                entry = new StringDataEntry(mapping.getTag(), Boolean.toString(value));
+                break;
+            case BOOLEAN:
+                entry = new BooleanDataEntry(mapping.getTag(), value);
+                break;
+            case DOUBLE:
+                entry = new DoubleDataEntry(mapping.getTag(), value ? 1. : 0.);
+                break;
+            case LONG:
+                entry = new LongDataEntry(mapping.getTag(), (long)(value ? 1 : 0));
+                break;
+            default:
+                log.error("MBD[{}] data type {} is not supported, tag [{}]", configuration.getDeviceName(), mapping.getType().getDataType(), mapping.getTag());
+                throw new IllegalArgumentException("Unsupported data type " + mapping.getType().getDataType());
+        }
+
+        return entry;
+    }
+
+    private byte[] convertToLsbOrder(InputRegister[] data, String format) {
+        byte[] outputBuf = new byte[data.length * 2];
+
+        if (format.equalsIgnoreCase(ModbusExtensionConstants.LITTLE_ENDIAN_BYTE_ORDER)) {
+            for (int i = 0; i < outputBuf.length; ++i) {
+                outputBuf[i] = data[i / 2].toBytes()[i % 2];
+            }
+            return outputBuf;
+        } else if (format.equalsIgnoreCase(ModbusExtensionConstants.BIG_ENDIAN_BYTE_ORDER)) {
+            for (int i = outputBuf.length - 1; i >= 0; --i) {
+                outputBuf[outputBuf.length - i - 1] = data[i / 2].toBytes()[i % 2];
+            }
+            return outputBuf;
+        }
+
+        int length = format.length();
+        int foundMarkers = 0;
+
+        for (int i = 0; i < length; ++i) {
+            char c = format.charAt(i);
+            int distance = -1;
+
+            if (Character.isDigit(c)) {
+                distance = c - '0';
+            } else if (Character.isLetter(c)) {
+                distance = Character.toLowerCase(c) - 'a';
+            }
+
+            if (distance >= 0 && outputBuf.length > distance) {
+                outputBuf[distance] = data[foundMarkers / 2].toBytes()[foundMarkers % 2];
+                foundMarkers++;
+            }
+        }
+
+        if (foundMarkers != outputBuf.length) {
+            return null;
+        }
+
+        return outputBuf;
+    }
+
+    private KvEntry convertToDataEntry(TagMapping mapping, InputRegister[] data) {
+        KvEntry entry = null;
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(convertToLsbOrder(data, mapping.getByteOrder()));
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+
+        switch (mapping.getType().getDataType()) {
+            case BOOLEAN:
+                if (ModbusExtensionConstants.MIN_BIT_INDEX_IN_REG > mapping.getBit() || mapping.getBit() > ModbusExtensionConstants.MAX_BIT_INDEX_IN_REG) {
+                    log.error("MBD[{}] wrong bit index {}, tag [{}]", configuration.getDeviceName(), mapping.getBit(), mapping.getTag());
+                    throw new IllegalArgumentException("Bit index is out of range, value " + mapping.getBit());
+                }
+
+                entry = new BooleanDataEntry(mapping.getTag(), ((byteBuffer.getShort() >> mapping.getBit()) & 1) == 1);
+                break;
+            case STRING:
+                entry = new StringDataEntry(mapping.getTag(), new String(byteBuffer.array()));
+                break;
+            case DOUBLE:
+                double doubleNumber = mapping.getRegisterCount() <= 2 ? byteBuffer.getFloat() : byteBuffer.getDouble();
+                entry = new DoubleDataEntry(mapping.getTag(), doubleNumber);
+                break;
+            case LONG:
+                long longNumber = 0;
+                switch (mapping.getRegisterCount()) {
+                    case 1:
+                        longNumber = byteBuffer.getShort();
+                        break;
+                    case 2:
+                        longNumber = byteBuffer.getInt();
+                        break;
+                    case 4:
+                        longNumber = byteBuffer.getLong();
+                        break;
+                }
+                entry = new LongDataEntry(mapping.getTag(), longNumber);
+                break;
+            default:
+                log.error("MBD[{}] data type {} is not supported, tag [{}]", configuration.getDeviceName(), mapping.getType().getDataType(), mapping.getTag());
+                throw new IllegalArgumentException("Unsupported data type " + mapping.getType().getDataType());
+        }
+
+        return entry;
+    }
+
+    public List<TagMapping> getAttributesMappings() {
+        return configuration.getAttributes();
+    }
+
+    public List<TagMapping> getTimeseriesMappings() {
+        return configuration.getTimeseries();
+    }
+
+    public List<KvEntry> getAttributesUpdate() {
+        return attributesUpdates;
+    }
+
+    public List<TsKvEntry> getTimeseriesUpdate() {
+        return timeseriesUpdates;
+    }
+
+    public void clearUpdates() {
+        attributesUpdates.clear();
+        timeseriesUpdates.clear();
+    }
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusService.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusService.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thingsboard.gateway.extensions.modbus;
+
+import org.thingsboard.gateway.extensions.ExtensionService;
+
+public interface ModbusService extends ExtensionService {
+
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusConfiguration.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thingsboard.gateway.extensions.modbus.conf;
+
+import lombok.Data;
+
+import java.util.List;
+
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusServerConfiguration;
+
+@Data
+public class ModbusConfiguration {
+    private List<ModbusServerConfiguration> servers;
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusExtensionConstants.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusExtensionConstants.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thingsboard.gateway.extensions.modbus.conf;
+
+public class ModbusExtensionConstants {
+    public static final int DEFAULT_MODBUS_TCP_PORT = 502;
+    public static final int DEFAULT_SOCKET_TIMEOUT = 3000; // in milliseconds
+
+    public static final int DEFAULT_POLL_PERIOD = 1000; // in milliseconds
+    public static final int NO_POLL_PERIOD_DEFINED = 0;
+
+    public static final int DEFAULT_REGISTER_COUNT = 1;
+
+    public static final int DEFAULT_BIT_INDEX_FOR_BOOLEAN = 0;
+    public static final int NO_BIT_INDEX_DEFINED = -1;
+    public static final int DEFAULT_REGISTER_COUNT_FOR_BOOLEAN = 1;
+
+    public static final int MIN_BIT_INDEX_IN_REG = 0;
+    public static final int MAX_BIT_INDEX_IN_REG = 15;
+
+    public static final String LITTLE_ENDIAN_BYTE_ORDER = "LITTLE";
+    public static final String BIG_ENDIAN_BYTE_ORDER = "BIG";
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusServerConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusServerConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.thingsboard.gateway.extensions.modbus.conf;
+
+import lombok.Data;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.DeviceMapping;
+import org.thingsboard.gateway.extensions.modbus.conf.transport.ModbusTransportConfiguration;
+
+import java.util.List;
+
+@Data
+public class ModbusServerConfiguration {
+    private ModbusTransportConfiguration transport;
+    private List<DeviceMapping> devices;
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/DataMapping.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/DataMapping.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thingsboard.gateway.extensions.modbus.conf.mapping;
+
+import lombok.Data;
+import org.thingsboard.gateway.extensions.common.conf.mapping.DataTypeMapping;
+
+@Data
+public class DataMapping {
+    private String key;
+    private DataTypeMapping type;
+    private String functionCode;
+    private int address; //TODO: If we need hexadecimal value, the String type need to be used as it does for the function code.
+    private Boolean bigEndian = true;
+    private int registerCount = 1;
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/DeviceMapping.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/DeviceMapping.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thingsboard.gateway.extensions.modbus.conf.mapping;
+
+import lombok.Data;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
+
+import java.util.Collections;
+import java.util.List;
+
+@Data
+public class DeviceMapping {
+    private int unitId;
+    private String deviceName;
+    private int attributesPollPeriod = ModbusExtensionConstants.DEFAULT_POLL_PERIOD;
+    private int timeseriesPollPeriod = ModbusExtensionConstants.DEFAULT_POLL_PERIOD;
+    private List<TagMapping> attributes = Collections.emptyList(); // FIXME: Is it a real case, what device is without attributes?
+    private List<TagMapping> timeseries = Collections.emptyList(); // FIXME: Is it a real case, what device is without timeseries?
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/TagMapping.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/TagMapping.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thingsboard.gateway.extensions.modbus.conf.mapping;
+
+import lombok.Data;
+import org.thingsboard.gateway.extensions.common.conf.mapping.DataTypeMapping;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
+
+@Data
+public class TagMapping {
+    private String tag;
+    private int pollPeriod = ModbusExtensionConstants.NO_POLL_PERIOD_DEFINED;
+    private DataTypeMapping type;
+    private int functionCode;
+    private int address;
+    private int registerCount = ModbusExtensionConstants.DEFAULT_REGISTER_COUNT;
+    private String byteOrder = ModbusExtensionConstants.BIG_ENDIAN_BYTE_ORDER;
+    private int bit = ModbusExtensionConstants.NO_BIT_INDEX_DEFINED;
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusIpTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusIpTransportConfiguration.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ package org.thingsboard.gateway.extensions.modbus.conf.transport;
+
+import lombok.Data;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
+
+@Data
+public class ModbusIpTransportConfiguration implements ModbusTransportConfiguration {
+    private String host;
+    private int port = ModbusExtensionConstants.DEFAULT_MODBUS_TCP_PORT;
+    private int timeout = ModbusExtensionConstants.DEFAULT_SOCKET_TIMEOUT;
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusRtuTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusRtuTransportConfiguration.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ package org.thingsboard.gateway.extensions.modbus.conf.transport;
+
+import lombok.Data;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
+
+@Data
+public class ModbusRtuTransportConfiguration implements ModbusTransportConfiguration {
+    private String portName;
+    private int timeout = ModbusExtensionConstants.DEFAULT_SOCKET_TIMEOUT;
+    private String encoding;
+    private int baudRate;
+    private int dataBits;
+    private float stopBits;
+    private String parity;
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusTcpTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusTcpTransportConfiguration.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ package org.thingsboard.gateway.extensions.modbus.conf.transport;
+
+public class ModbusTcpTransportConfiguration extends ModbusIpTransportConfiguration {
+
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusTransportConfiguration.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ package org.thingsboard.gateway.extensions.modbus.conf.transport;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Created by ashvayka on 16.01.17.
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ModbusTcpTransportConfiguration.class, name = "tcp"),
+        @JsonSubTypes.Type(value = ModbusUdpTransportConfiguration.class, name = "udp"),
+        @JsonSubTypes.Type(value = ModbusRtuTransportConfiguration.class, name = "rtu")})
+public interface ModbusTransportConfiguration {
+
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusUdpTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusUdpTransportConfiguration.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.thingsboard.gateway.extensions.modbus.conf.transport;
+
+public class ModbusUdpTransportConfiguration extends ModbusIpTransportConfiguration {
+
+}

--- a/src/main/java/org/thingsboard/gateway/service/TenantServiceRegistry.java
+++ b/src/main/java/org/thingsboard/gateway/service/TenantServiceRegistry.java
@@ -23,6 +23,7 @@ import org.thingsboard.gateway.extensions.ExtensionService;
 import org.thingsboard.gateway.extensions.file.DefaultFileTailService;
 import org.thingsboard.gateway.extensions.http.DefaultHttpService;
 import org.thingsboard.gateway.extensions.http.HttpService;
+import org.thingsboard.gateway.extensions.modbus.DefaultModbusService;
 import org.thingsboard.gateway.extensions.mqtt.client.DefaultMqttClientService;
 import org.thingsboard.gateway.extensions.opc.DefaultOpcUaService;
 import org.thingsboard.gateway.service.conf.TbExtensionConfiguration;
@@ -51,6 +52,7 @@ public class TenantServiceRegistry implements ExtensionServiceCreation {
     private static final String OPC_EXTENSION = "OPC UA";
     private static final String MQTT_EXTENSION = "MQTT";
     private static final String FILE_EXTENSION = "FILE";
+    private static final String MODBUS_EXTENSION = "MODBUS";
 
     public TenantServiceRegistry() {
         this.extensions = new HashMap<>();
@@ -118,6 +120,8 @@ public class TenantServiceRegistry implements ExtensionServiceCreation {
                 return new DefaultHttpService(gateway);
             case MQTT_EXTENSION:
                 return new DefaultMqttClientService(gateway);
+            case MODBUS_EXTENSION:
+                return new DefaultModbusService(gateway);
             default:
                 throw new IllegalArgumentException("Extension: " + type + " is not supported!");
         }

--- a/src/main/resources/modbus-config.json
+++ b/src/main/resources/modbus-config.json
@@ -1,0 +1,126 @@
+{
+  "servers": [
+    {
+      "transport":
+      {
+        "type": "rtu",
+        "portName": "COM1",
+        "encoding": "ascii",
+        "timeout": 5000,
+        "baudRate": 115200,
+        "dataBits": 7,
+        "stopBits": 1,
+        "parity": "even"
+      },
+      "devices": [
+        {
+          "unitId": 115,
+          "deviceName": "Pressure Sensor",
+          "timeseries": [
+            {
+              "tag": "Pressure",
+              "type": "double",
+              "byteOrder": "1032",
+              "functionCode": 3,
+              "address": 1001,
+              "registerCount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "transport":
+      {
+        "type": "tcp",
+        "host": "localhost",
+        "port": 503
+      },
+      "devices": [
+        {
+          "unitId": 1,
+          "deviceName": "Temp Sensor",
+          "timeseries": [
+            {
+              "tag": "Coil",
+              "type": "boolean",
+              "functionCode": 1,
+              "address": 75
+            },
+            {
+              "tag": "DiscrInput",
+              "type": "boolean",
+              "functionCode": 2,
+              "address": 135
+            },
+            {
+              "tag": "BooleanValue",
+              "type": "boolean",
+              "functionCode": 3,
+              "address": 150,
+              "bit": 14,
+              "byteOrder": "little"
+            }
+          ]
+        },
+        {
+          "unitId": 2,
+          "deviceName": "Humidity Sensor",
+          "attributesPollPeriod": 5000,
+          "timeseriesPollPeriod": 5000,
+          "attributes": [
+            {
+              "tag": "Serial number",
+              "type": "string",
+              "functionCode": 4,
+              "address": 146,
+              "registerCount": 6,
+              "pollPeriod": 3600000
+            }
+          ],
+          "timeseries": [
+            {
+              "tag": "ShortValue",
+              "type": "long",
+              "functionCode": 4,
+              "address": 126,
+              "byteOrder": "LITTLE"
+            },
+            {
+              "tag": "IntValue",
+              "type": "long",
+              "functionCode": 3,
+              "address": 152,
+              "registerCount": 2,
+              "byteOrder": "BADC"
+            },
+            {
+              "tag": "LongValue",
+              "type": "long",
+              "functionCode": 3,
+              "address": 154,
+              "registerCount": 4,
+              "byteOrder": "AB CD EF GH"
+            },
+            {
+              "tag": "FloatValue",
+              "type": "double",
+              "byteOrder": "2301",
+              "functionCode": 3,
+              "address": 158,
+              "registerCount": 2
+            },
+            {
+              "tag": "DoubleValue",
+              "type": "double",
+              "byteOrder": "23 01 67 45",
+              "functionCode": 4,
+              "address": 160,
+              "registerCount": 4
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The service supports the following Modbus protocols: RTU, ASCII, TCP, UDP.
The service can simultaneously communicate with several Modbus servers, each of them you can configure separately.

The supported functions:
- Read Coils (code 1)
- Read Discrete Inputs (code 2)
- Read Multiple Holding Registers (code 3)
- Read Input Registers (code 4)