### PR TITLE
Fixing deviceType in MQTT not propagate up to Thingsboard 

### DIFF
--- a/src/main/java/org/thingsboard/gateway/extensions/mqtt/client/listener/MqttDeviceStateChangeMessageListener.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/mqtt/client/listener/MqttDeviceStateChangeMessageListener.java
@@ -57,12 +57,12 @@ public class MqttDeviceStateChangeMessageListener extends AbstractJsonConverter 
                 deviceName = eval(document, mapping.getDeviceNameJsonExpression());
             }
 
-            if (!StringUtils.isEmpty(mapping.getDeviceTypeJsonExpression())) {
+            if (!StringUtils.isEmpty(mapping.getDeviceTypeTopicExpression())) {
                 deviceType = eval(topic);
-            } else if (!StringUtils.isEmpty(mapping.getDeviceTypeTopicExpression())) {
+            } else if (!StringUtils.isEmpty(mapping.getDeviceTypeJsonExpression())) {
                 String data = new String(msg.getPayload(), StandardCharsets.UTF_8);
                 DocumentContext document = JsonPath.parse(data);
-                deviceType = eval(document, mapping.getDeviceTypeTopicExpression());
+                deviceType = eval(document, mapping.getDeviceTypeJsonExpression());
             }
 
             if (deviceName != null) {

--- a/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
+++ b/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
@@ -204,12 +204,14 @@ public class MqttGatewayService implements GatewayService, MqttHandler, MqttClie
     @Override
     public MqttDeliveryFuture onDeviceConnect(final String deviceName, final String deviceType) {
         final int msgId = msgIdSeq.incrementAndGet();
-        byte[] msgData = toBytes(newNode().put("device", deviceName));
+        ObjectNode gwMsg = newNode().put("device", deviceName);
+        gwMsg.put("type", deviceType);
+        byte[] msgData = toBytes(gwMsg);
         log.info("[{}] Device Connected!", deviceName);
         devices.putIfAbsent(deviceName, new DeviceInfo(deviceName, deviceType));
         return persistMessage(GATEWAY_CONNECT_TOPIC, msgId, msgData, deviceName,
                 message -> {
-                    log.info("[{}][{}] Device connect event is reported to Thingsboard!", deviceName, msgId);
+                    log.info("[{}][{}][{}] Device connect event is reported to Thingsboard!", deviceName, deviceType, msgId);
                 },
                 error -> log.warn("[{}][{}] Failed to report device connection!", deviceName, msgId, error));
 


### PR DESCRIPTION
Fixed 2 issues where related to deviceType in MQTT Gateway service:

- deviceType not inserted into MQTT message that being sent to upstream Thingsboard backend.
- Evaluation condition of deviceTypeTopicExpression and deviceTypeJsonExpression is incorrect.