### PR TITLE
BUGFIX: Gateway send an integer attribute to device as a string value

### DIFF
--- a/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
+++ b/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
@@ -579,7 +579,7 @@ public class MqttGatewayService implements GatewayService, MqttHandler, MqttClie
             response.data(Optional.empty());
         } else if (value.isBoolean()) {
             response.data(Optional.of(new BooleanDataEntry(key, value.asBoolean())));
-        } else if (value.isLong()) {
+        } else if (value.canConvertToLong()) {
             response.data(Optional.of(new LongDataEntry(key, value.asLong())));
         } else if (value.isDouble()) {
             response.data(Optional.of(new DoubleDataEntry(key, value.asDouble())));

--- a/src/main/java/org/thingsboard/gateway/util/JsonTools.java
+++ b/src/main/java/org/thingsboard/gateway/util/JsonTools.java
@@ -84,7 +84,7 @@ public class JsonTools {
             JsonNode value = field.getValue();
             if (value.isBoolean()) {
                 attributes.add(new BooleanDataEntry(key, value.asBoolean()));
-            } else if (value.isLong()) {
+            } else if (value.canConvertToLong()) {
                 attributes.add(new LongDataEntry(key, value.asLong()));
             } else if (value.isDouble()) {
                 attributes.add(new DoubleDataEntry(key, value.asDouble()));


### PR DESCRIPTION
BUG: When set a share scope attribute as an integer value, the gateway forward attribut update request to device as a string value.

FIX: JsonNode.isLong() return false when the value is not a 64bit value。Use canConvertToLong() instead.