### PR TITLE
Fixed get configuration request payload

### DIFF
--- a/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
+++ b/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
@@ -662,7 +662,7 @@ public class MqttGatewayService implements GatewayService, MqttHandler, MqttClie
             tbClient.on(GATEWAY_ATTRIBUTES_TOPIC, this).await(connection.getConnectionTimeout(), TimeUnit.MILLISECONDS);
             tbClient.on(GATEWAY_RPC_TOPIC, this).await(connection.getConnectionTimeout(), TimeUnit.MILLISECONDS);
 
-            byte[] msgData = toBytes(newNode().put("shared", "configuration"));
+            byte[] msgData = toBytes(newNode().put("sharedKeys", "configuration"));
             persistMessage(DEVICE_GET_ATTRIBUTES_REQUEST_TOPIC, msgIdSeq.incrementAndGet(), msgData, null,
                     null,
                     error -> log.warn("Error getiing attributes", error));


### PR DESCRIPTION
The right request payload should be `{"sharedKeys":"configuration"}` instead of `{"shared":"configuration"}`.

TB will return all attributes if the request payload was wrong, and once the response payload bigger than  8192 bytes, Gateway will be crashed.

```
[nioEventLoopGroup-2-1] WARN  i.n.channel.DefaultChannelPipeline - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.NullPointerException: null
	at nl.jk5.mqtt.MqttPingHandler.channelRead(MqttPingHandler.java:34)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
...
```

![image](https://user-images.githubusercontent.com/5079364/43891218-5b62a1c4-9bfb-11e8-8263-e80be69f335b.png)

