### PR TITLE
Mqtt/json mapping: use correct pattern for deviceType TopicExpression

### DIFF
--- a/src/main/java/org/thingsboard/gateway/extensions/mqtt/client/conf/mapping/MqttJsonConverter.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/mqtt/client/conf/mapping/MqttJsonConverter.java
@@ -127,7 +127,7 @@ public class MqttJsonConverter extends BasicJsonConverter implements MqttDataCon
 
     private String evalDeviceType(String topic) {
         if (deviceTypeTopicPattern == null) {
-            deviceTypeTopicPattern = Pattern.compile(deviceTypeJsonExpression);
+            deviceTypeTopicPattern = Pattern.compile(deviceTypeTopicExpression);
         }
         Matcher matcher = deviceTypeTopicPattern.matcher(topic);
         while (matcher.find()) {


### PR DESCRIPTION
Using a deviceType**Topic**Expression with mqtt/json mapping always leads to errors, since the deviceType**Json**Expression was used.
This fixes this issue.