### PR TITLE
Multiple tags write via Server-side RPC for OPC UA extension

### DIFF
--- a/src/main/java/org/thingsboard/gateway/extensions/opc/OpcUaDevice.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/opc/OpcUaDevice.java
@@ -22,6 +22,7 @@ import org.thingsboard.gateway.extensions.opc.conf.mapping.AttributesMapping;
 import org.thingsboard.gateway.extensions.opc.conf.mapping.DeviceMapping;
 import org.thingsboard.gateway.extensions.common.conf.mapping.KVMapping;
 import org.thingsboard.gateway.extensions.opc.conf.mapping.TimeseriesMapping;
+import org.thingsboard.gateway.extensions.opc.scan.OpcUaNode;
 import org.thingsboard.server.common.data.kv.*;
 
 import java.util.*;
@@ -33,7 +34,7 @@ import java.util.stream.Collectors;
 @Data
 public class OpcUaDevice {
 
-    private final NodeId nodeId;
+    private final OpcUaNode opcNode;
     private final DeviceMapping mapping;
     private final Map<String, NodeId> tagKeysMap = new HashMap<>();
     private final Map<NodeId, String> tagIdsMap = new HashMap<>();
@@ -68,12 +69,14 @@ public class OpcUaDevice {
         return tagKeysMap.put(kv.getKey(), kv.getValue());
     }
 
-    public void calculateDeviceName(Map<String, String> deviceNameTagValues) {
+    public String calculateDeviceName(Map<String, String> deviceNameTagValues) {
         String deviceNameTmp = mapping.getDeviceNamePattern();
         for (Map.Entry<String, String> kv : deviceNameTagValues.entrySet()) {
             deviceNameTmp = deviceNameTmp.replace(escape(kv.getKey()), kv.getValue());
         }
         this.deviceName = deviceNameTmp;
+
+        return this.deviceName;
     }
 
     public void updateTag(NodeId tagId, DataValue dataValue) {
@@ -115,6 +118,10 @@ public class OpcUaDevice {
         } else {
             return Collections.emptyList();
         }
+    }
+
+    public NodeId getTagNodeId(String tag) {
+        return tagKeysMap.get(tag);
     }
 
     private List<KvEntry> getKvEntries(List<? extends KVMapping> mappings) {

--- a/src/main/java/org/thingsboard/gateway/extensions/opc/OpcUaDeviceAware.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/opc/OpcUaDeviceAware.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright © 2016-2018 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.gateway.extensions.opc;
+
+public interface OpcUaDeviceAware {
+    OpcUaDevice getDevice(String deviceName);
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/opc/OpcUaDeviceAware.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/opc/OpcUaDeviceAware.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2016-2018 The Thingsboard Authors
+ * Copyright © 2017 The Thingsboard Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/thingsboard/gateway/extensions/opc/rpc/RpcProcessor.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/opc/rpc/RpcProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2016-2018 The Thingsboard Authors
+ * Copyright © 2017 The Thingsboard Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.gateway.extensions.opc.rpc;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -76,7 +77,7 @@ public class RpcProcessor implements RpcCommandListener {
         }
 
         Map<String, String> results = new HashMap<>();
-        HashMap<String, Object> values = JsonTools.fromStringToMap(command.getParams());
+        HashMap<String, Object> values = JsonTools.fromString(command.getParams(), new TypeReference<HashMap<String, Object>>() {});
 
         Map<String, NodeId> nodeIds = resolveNodeIds(device, values.keySet());
         Set<String> notFoundTags = Sets.difference(values.keySet(), nodeIds.keySet());

--- a/src/main/java/org/thingsboard/gateway/extensions/opc/rpc/RpcProcessor.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/opc/rpc/RpcProcessor.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright © 2016-2018 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.gateway.extensions.opc.rpc;
+
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.*;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
+import org.thingsboard.gateway.extensions.opc.OpcUaDevice;
+import org.thingsboard.gateway.extensions.opc.OpcUaDeviceAware;
+import org.thingsboard.gateway.extensions.opc.scan.OpcUaNode;
+import org.thingsboard.gateway.extensions.opc.util.OpcUaUtils;
+import org.thingsboard.gateway.service.RpcCommandListener;
+import org.thingsboard.gateway.service.data.RpcCommandData;
+import org.thingsboard.gateway.service.data.RpcCommandResponse;
+import org.thingsboard.gateway.service.gateway.GatewayService;
+import org.thingsboard.gateway.util.JsonTools;
+
+import java.util.*;
+
+@Slf4j
+public class RpcProcessor implements RpcCommandListener {
+    private static final String RESPONSE_STATUS_OK = "ok";
+    private static final String RESPONSE_FIELD_ERROR = "error";
+
+    private static final String RPC_WRITE = "write";
+
+    private final GatewayService gateway;
+    private final OpcUaClient client;
+    private final OpcUaDeviceAware deviceContainer;
+
+    public RpcProcessor(GatewayService gateway, OpcUaClient client, OpcUaDeviceAware deviceContainer) {
+        this.gateway = gateway;
+        this.client = client;
+        this.deviceContainer = deviceContainer;
+    }
+
+    @Override
+    public void onRpcCommand(String deviceName, RpcCommandData command) {
+        log.debug("RPC received: device='{}', command={}", deviceName, command);
+
+        OpcUaDevice device = deviceContainer.getDevice(deviceName);
+        if (device == null) {
+            log.warn("No device '{}' found for RPC {}", deviceName, command);
+            gateway.onDeviceRpcResponse(createErrorResponse(command.getRequestId(),
+                                        deviceName,
+                                        String.format("No device '%s' found", deviceName)));
+            return;
+        }
+
+        if (!RPC_WRITE.equals(command.getMethod())) {
+            log.warn("Unknown RPC method '{}'", command.getMethod());
+            gateway.onDeviceRpcResponse(createErrorResponse(command.getRequestId(),
+                                        deviceName,
+                                        String.format("Unsupported RPC method '%s'", command.getMethod())));
+            return;
+        }
+
+        Map<String, String> results = new HashMap<>();
+        HashMap<String, Object> values = JsonTools.fromStringToMap(command.getParams());
+
+        Map<String, NodeId> nodeIds = resolveNodeIds(device, values.keySet());
+        Set<String> notFoundTags = Sets.difference(values.keySet(), nodeIds.keySet());
+
+        if (!notFoundTags.isEmpty()) {
+            log.warn("Failed to find tags {}", notFoundTags);
+            results.putAll(createTagsErrorResponse(notFoundTags, "No tag found"));
+        }
+
+        Map<String, NodeId> types = requestOpcTypes(nodeIds);
+        Set<String> notResolvedTags = Sets.difference(nodeIds.keySet(), types.keySet());
+
+        if (!notResolvedTags.isEmpty()) {
+            log.warn("Failed to resolve OPC type for tags {}", notResolvedTags);
+            results.putAll(createTagsErrorResponse(notResolvedTags, "Failed to resolve OPC type"));
+        }
+
+        try {
+            List<WriteValue> request = createWriteRequest(nodeIds, types, values, results);
+
+            log.trace("Writing values to OPC server for tags {}", types.keySet());
+
+            WriteResponse writeResponse = client.write(request).get();
+            results.putAll(processWriteResponse(writeResponse, types));
+        } catch (Exception e) {
+            log.warn("OPC write failed", e);
+            results.putAll(createTagsErrorResponse(types.keySet(), "OPC write failed: " + e.getMessage()));
+        }
+
+        gateway.onDeviceRpcResponse(createResponse(command.getRequestId(), deviceName, results));
+    }
+
+    private List<WriteValue> createWriteRequest(Map<String, NodeId> tags,
+                                                Map<String, NodeId> types,
+                                                Map<String, Object> values,
+                                                Map<String, String> results) {
+        List<WriteValue> opcValues = new LinkedList<>();
+        Set<String> failedTags= new HashSet<>();
+
+        types.forEach((tag, typeNodeId) -> {
+            Object rawValue = values.get(tag);
+            try {
+                Variant opcValue = OpcUaUtils.convertToOpcValue(typeNodeId, rawValue);
+                opcValues.add(new WriteValue(tags.get(tag), AttributeId.Value.uid(), null, DataValue.valueOnly(opcValue)));
+            } catch (Exception e) {
+                log.warn("Failed to convert '{}' tag's value '{}' to OPC format (OPC type node {})", tag, rawValue, typeNodeId, e);
+                results.put(tag, e.getMessage());
+                failedTags.add(tag);
+            }
+        });
+
+        if (!failedTags.isEmpty()) {
+            types.keySet().removeAll(failedTags);
+        }
+
+        return opcValues;
+    }
+
+    private Map<String, String> processWriteResponse(WriteResponse response, Map<String, NodeId> tags) {
+        Map<String, String> results = new HashMap<>();
+
+        int i = 0;
+        for (String tag : tags.keySet()) {
+            StatusCode statusCode = response.getResults()[i++];
+            if (statusCode.isGood()) {
+                log.debug("OPC write success for tag '{}'", tag);
+                results.put(tag, RESPONSE_STATUS_OK);
+            } else {
+                log.warn("OPC write failed for tag '{}': reason={}", tag, statusCode);
+                results.put(tag, "OPC error code: " + statusCode);
+            }
+        }
+
+        return results;
+    }
+
+    private Map<String, NodeId> requestOpcTypes(Map<String, NodeId> tags) {
+        Map<String, NodeId> resolvedTypes = new HashMap<>();
+
+        try {
+            log.trace("Requesting OPC data type for tags {}", tags.keySet());
+
+            List<ReadValueId> readIds = new LinkedList<>();
+            tags.forEach((tag, nodeId) -> readIds.add(
+                    new ReadValueId(nodeId, AttributeId.DataType.uid(), null, QualifiedName.NULL_VALUE)));
+
+            ReadResponse readResponse = client.read(0.0, TimestampsToReturn.Neither, readIds).get();
+
+            int readRespIndex = 0;
+            for (Map.Entry<String, NodeId> entry : tags.entrySet()) {
+                DataValue dv = readResponse.getResults()[readRespIndex++];
+
+                if (dv.getStatusCode().isGood()) {
+                    NodeId type = (NodeId) dv.getValue().getValue();
+                    log.trace("Got OPC type node for tag '{}': {}", entry.getKey(), type);
+
+                    resolvedTypes.put(entry.getKey(), type);
+                } else {
+                    log.warn("Failed to request OPC type node for tag '{}': reason={}", entry.getKey(), dv.getStatusCode());
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to request OPC data type for tags '{}': ", tags.keySet(), e);
+        }
+
+        return resolvedTypes;
+    }
+
+    private Map<String, NodeId> resolveNodeIds(OpcUaDevice device, Set<String> tags) {
+        Set<String> pendingTags = new HashSet<>();
+        Map<String, NodeId> tagsToNodeId = new HashMap<>();
+
+        for (String tag : tags) {
+            NodeId tagNodeId = device.getTagNodeId(tag);
+            if (tagNodeId == null) {
+                pendingTags.add(tag);
+            } else {
+                tagsToNodeId.put(tag, tagNodeId);
+            }
+        }
+
+        if (!pendingTags.isEmpty()) {
+            log.trace("Looking up OPC server for tags {}", pendingTags);
+
+            OpcUaNode node = device.getOpcNode();
+            Map<String, NodeId> resolvedTags = OpcUaUtils.lookupTags(client,
+                                                                     node.getNodeId(),
+                                                                     node.getName(),
+                                                                     pendingTags);
+            tagsToNodeId.putAll(resolvedTags);
+        }
+
+        return tagsToNodeId;
+    }
+
+    private Map<String, String> createTagsErrorResponse(Set<String> tags, String error) {
+        Map<String, String> errors = new HashMap<>();
+        tags.forEach((tag)->errors.put(tag, error));
+        return errors;
+    }
+
+    private RpcCommandResponse createErrorResponse(int requestId, String deviceName, String errorDescription) {
+        RpcCommandResponse response = new RpcCommandResponse();
+        response.setRequestId(requestId);
+        response.setDeviceName(deviceName);
+
+        Map<String, String> data = new HashMap<>();
+        data.put(RESPONSE_FIELD_ERROR, errorDescription);
+
+        response.setData(JsonTools.toString(data));
+
+        return response;
+    }
+
+    private RpcCommandResponse createResponse(int requestId, String deviceName, Map<String, String> data) {
+        RpcCommandResponse response = new RpcCommandResponse();
+        response.setRequestId(requestId);
+        response.setDeviceName(deviceName);
+        response.setData(JsonTools.toString(data));
+
+        return response;
+    }
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/opc/util/OpcUaUtils.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/opc/util/OpcUaUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2016-2018 The Thingsboard Authors
+ * Copyright © 2017 The Thingsboard Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/thingsboard/gateway/extensions/opc/util/OpcUaUtils.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/opc/util/OpcUaUtils.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright © 2016-2018 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.gateway.extensions.opc.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.stack.core.Identifiers;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseDirection;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseResultMask;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowseDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.toList;
+
+@Slf4j
+public class OpcUaUtils {
+    public static final String DATE_TIME_FORMAT = "yyyy-M-d H:m:s.SSS z";
+
+    public static Map<String, NodeId> lookupTags(OpcUaClient client, NodeId nodeId, String deviceNodeName, Set<String> tags) {
+        Map<String, NodeId> values = new HashMap<>();
+        try {
+            BrowseResult browseResult = client.browse(getBrowseDescription(nodeId)).get();
+            List<ReferenceDescription> references = toList(browseResult.getReferences());
+
+            for (ReferenceDescription rd : references) {
+                NodeId childId;
+                if (rd.getNodeId().isLocal()) {
+                    childId = rd.getNodeId().local().get();
+                } else {
+                    log.trace("Ignoring remote node: {}", rd.getNodeId());
+                    continue;
+                }
+
+                String browseName = rd.getBrowseName().getName();
+                String name;
+                String childIdStr = childId.getIdentifier().toString();
+                if (childIdStr.contains(deviceNodeName)) {
+                    name = childIdStr.substring(childIdStr.indexOf(deviceNodeName) + deviceNodeName.length() + 1, childIdStr.length());
+                } else {
+                    name = rd.getBrowseName().getName();
+                }
+                if (tags.contains(name)) {
+                    values.put(name, childId);
+                }
+                // recursively browse to children
+                values.putAll(lookupTags(client, childId, deviceNodeName, tags));
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Browsing nodeId={} failed: {}", nodeId, e.getMessage(), e);
+        }
+        return values;
+    }
+
+    public static BrowseDescription getBrowseDescription(NodeId nodeId) {
+        return new BrowseDescription(
+                nodeId,
+                BrowseDirection.Forward,
+                Identifiers.References,
+                true,
+                uint(NodeClass.Object.getValue() | NodeClass.Variable.getValue()),
+                uint(BrowseResultMask.All.getValue())
+        );
+    }
+
+    public static Variant convertToOpcValue(NodeId typeNode, Object value) {
+        Number numberValue = (value instanceof Number) ? (Number) value : null;
+
+        try {
+            if (typeNode.equals(Identifiers.Double)) {
+                return new Variant(Double.valueOf(numberValue.doubleValue()));
+            } else if (typeNode.equals(Identifiers.Float)) {
+                return new Variant(Float.valueOf(numberValue.floatValue()));
+            } else if (typeNode.equals(Identifiers.String)) {
+                return new Variant(value);
+            } else if (typeNode.equals(Identifiers.Integer)|| typeNode.equals(Identifiers.Int32)) {
+                return new Variant(Integer.valueOf(numberValue.intValue()));
+            } else if (typeNode.equals(Identifiers.Int16)) {
+                return new Variant(Short.valueOf(numberValue.shortValue()));
+            } else if (typeNode.equals(Identifiers.Int64)) {
+                return new Variant(Long.valueOf(numberValue.longValue()));
+            } else if (typeNode.equals(Identifiers.UInteger) || typeNode.equals(Identifiers.UInt32)) {
+                return new Variant(UInteger.valueOf(numberValue.intValue()));
+            } else if (typeNode.equals(Identifiers.UInt16)) {
+                return new Variant(UShort.valueOf(numberValue.shortValue()));
+            } else if (typeNode.equals(Identifiers.UInt64)) {
+                return new Variant(ULong.valueOf(numberValue.longValue()));
+            } else if (typeNode.equals(Identifiers.Boolean)) {
+                return new Variant(value);
+            } else if (typeNode.equals(Identifiers.Byte)) {
+                return new Variant(UByte.valueOf(numberValue.byteValue()));
+            } else if (typeNode.equals(Identifiers.SByte)) {
+                return new Variant(Byte.valueOf(numberValue.byteValue()));
+            } else if (typeNode.equals(Identifiers.ByteString)) {
+                return new Variant(ByteString.of(Base64.getDecoder().decode((String) value)));
+            } else if (typeNode.equals(Identifiers.DateTime)) {
+                if (value instanceof String) {
+                    DateFormat df = new SimpleDateFormat(DATE_TIME_FORMAT);
+                    return new Variant(new DateTime(df.parse((String) value)));
+                } else {
+                    return new Variant(new DateTime(new Date(numberValue.longValue())));
+                }
+            } else {
+                Integer opcType = ((Integer) typeNode.getIdentifier());
+                log.error("Failed to convert value '{}' to OPC format: unsupported OPC type {}", value, opcType);
+                throw new IllegalArgumentException("Unsupported OPC type " + opcType);
+            }
+        } catch (ParseException e) {
+            log.error("Failed to convert value '{}' to OPC format: wrong date/time format", value);
+            throw new IllegalArgumentException(String.format("Wrong date/time format. Expected '%s'", DATE_TIME_FORMAT));
+        } catch (Exception e) {
+            log.error("Failed to cast value to opc type", e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
+++ b/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
@@ -473,7 +473,7 @@ public class MqttGatewayService implements GatewayService, MqttHandler, MqttClie
             RpcCommandData rpcCommand = new RpcCommandData();
             rpcCommand.setRequestId(data.get("id").asInt());
             rpcCommand.setMethod(data.get("method").asText());
-            rpcCommand.setParams(JsonTools.toString(data.get("params")));
+            rpcCommand.setParams(data.get("params").asText());
             listeners.forEach(listener -> callbackExecutor.submit(() -> {
                 try {
                     listener.onRpcCommand(deviceName, rpcCommand);

--- a/src/main/java/org/thingsboard/gateway/util/JsonTools.java
+++ b/src/main/java/org/thingsboard/gateway/util/JsonTools.java
@@ -17,7 +17,6 @@ package org.thingsboard.gateway.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -50,9 +49,9 @@ public class JsonTools {
         }
     }
 
-    public static <T> T fromStringToMap(String data) {
+    public static <T> T fromString(String data, TypeReference<T> type) {
         try {
-            return JSON.readValue(data, new TypeReference<T>(){});
+            return JSON.readValue(data, type);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/thingsboard/gateway/util/JsonTools.java
+++ b/src/main/java/org/thingsboard/gateway/util/JsonTools.java
@@ -16,6 +16,8 @@
 package org.thingsboard.gateway.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -23,10 +25,7 @@ import org.thingsboard.server.common.data.kv.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by ashvayka on 19.01.17.
@@ -51,9 +50,25 @@ public class JsonTools {
         }
     }
 
+    public static <T> T fromStringToMap(String data) {
+        try {
+            return JSON.readValue(data, new TypeReference<T>(){});
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static String toString(JsonNode node) {
         try {
             return JSON.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String toString(Map<String, String> map) {
+        try {
+            return JSON.writeValueAsString(map);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Features

1. Multiple tags write.
2. Supported OPC types  `Boolean, Byte, Char, Short, Word, DWord, Long, LLong, QWord, Float, Double, Date, String`.

## Environment
KEPServerEx 6.6

## Format

#### Request
[TB man page](https://thingsboard.io/docs/user-guide/rpc/#server-side-rpc-api) on Server-side RPC format.

**method**: `write`
**params**: _see below_

```json
{
    "TagName1": <value1>,
    "TagName2": <value2>
}
```

#### Response
1. Global error
```json
{
    "error": "<error_description>"
}
```
2. Success or fail on tag.
```json
{
    "TagName1": "ok|<error_description>",
    "TagName2": "ok|<error_description>"
}
```
## Examples
#### Request
```json
{
    "BooleanTag": true,
    "DoubleTag": 3.14,
    "LongTag": 12345,
    "StringTag": "Hello World!",

    "DateTagMillisInGmtTimeZone": 1543922564000,
    "DateTagAsString": "2018-12-06 12:40:50.123 PST",

    "Group.SubGroup.WordTag": 3456
}
```
#### Response
```json
{
    "error": "Unsupported RPC method"
}
```
```json
{
    "SuccesWriteTag": "ok",
    "ErrorWriteTag": "No tag found"
}
```