### PR TITLE
Multiple tags write via Server-side RPC for Modbus extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <bouncycastle.version>1.52</bouncycastle.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.1.7</logback.version>
-        <j2mod.version>2.4.1</j2mod.version>
+        <j2mod.version>2.5.3</j2mod.version>
         <pkg.name>tb-gateway</pkg.name>
         <pkg.user>thingsboard</pkg.user>
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusClient.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusClient.java
@@ -27,18 +27,21 @@ import com.ghgande.j2mod.modbus.util.SerialParameters;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
 import org.thingsboard.gateway.extensions.modbus.conf.ModbusServerConfiguration;
-import org.thingsboard.gateway.extensions.modbus.conf.mapping.TagMapping;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.PollingTagMapping;
 import org.thingsboard.gateway.extensions.modbus.conf.transport.*;
+import org.thingsboard.gateway.extensions.modbus.rpc.RpcProcessor;
+import org.thingsboard.gateway.service.data.RpcCommandSubscription;
 import org.thingsboard.gateway.service.gateway.GatewayService;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class ModbusClient {
+public class ModbusClient implements ModbusDeviceAware {
 
     private GatewayService gateway;
     private ModbusServerConfiguration configuration;
@@ -47,17 +50,24 @@ public class ModbusClient {
     private ModbusTransaction transaction;
     private String serverName;
 
-    private List<ModbusDevice> devices;
+    private Map<String, ModbusDevice> devices;
 
     private ScheduledExecutorService executor;
+    private RpcProcessor rpcProcessor;
 
     public ModbusClient(GatewayService gateway, ModbusServerConfiguration configuration) {
         this.gateway = gateway;
         this.configuration = configuration;
         this.client = createClient(this.configuration.getTransport());
         this.executor = Executors.newSingleThreadScheduledExecutor();
-        this.devices = this.configuration.getDevices().stream().map(conf -> new ModbusDevice(conf)).collect(Collectors.toList());
+        this.devices = this.configuration.getDevices().stream().collect(Collectors.toMap(c -> c.getDeviceName(), c -> new ModbusDevice(c)));
         this.serverName = createServerName(this.configuration.getTransport());
+        this.rpcProcessor = new RpcProcessor(this.gateway, this.client, this);
+    }
+
+    @Override
+    public ModbusDevice getDevice(String deviceName) {
+        return devices.get(deviceName);
     }
 
     private String createServerName(ModbusTransportConfiguration configuration) {
@@ -123,11 +133,12 @@ public class ModbusClient {
     private void firstRead() {
         log.info("MBS[{}] going to first read", serverName);
 
-        devices.stream().forEach(device -> {
+        devices.forEach((name, device) -> {
             readTags(device, device.getAttributesMappings());
             readTags(device, device.getTimeseriesMappings());
 
             gateway.onDeviceConnect(device.getName(), null);
+            gateway.subscribe(new RpcCommandSubscription(device.getName(), rpcProcessor));
 
             log.info("MBS[{}] connected new MBD[{}]", serverName, device.getName());
 
@@ -138,7 +149,7 @@ public class ModbusClient {
     private void startPolling() {
         log.info("Start polling MBS[{}]", serverName);
 
-        devices.stream().forEach(device -> {
+        devices.forEach((name, device) -> {
             device.getSortedTagMappings().entrySet().stream().forEach(tags -> {
                 log.info("MBS[{}] Schedule polling [{}] slave for tag(s) [{}], period {} ms",
                         serverName,
@@ -165,11 +176,11 @@ public class ModbusClient {
         }
     }
 
-    private void readTags(ModbusDevice device, List<TagMapping> mappings) {
+    private void readTags(ModbusDevice device, List<PollingTagMapping> mappings) {
         mappings.stream().forEach(m -> readTag(device, m));
     }
 
-    private void readTag(ModbusDevice device, TagMapping mapping) {
+    private void readTag(ModbusDevice device, PollingTagMapping mapping) {
         ModbusRequest request = createRequest(device, mapping);
         transaction.setRequest(request);
         try {
@@ -180,7 +191,7 @@ public class ModbusClient {
         }
     }
 
-    private ModbusRequest createRequest(ModbusDevice device, TagMapping mapping) {
+    private ModbusRequest createRequest(ModbusDevice device, PollingTagMapping mapping) {
         ModbusRequest request = null;
 
         switch (mapping.getFunctionCode()) {
@@ -207,7 +218,7 @@ public class ModbusClient {
         return request;
     }
 
-    private void processResponse(ModbusResponse response, ModbusDevice device, TagMapping mapping) {
+    private void processResponse(ModbusResponse response, ModbusDevice device, PollingTagMapping mapping) {
         switch (mapping.getFunctionCode()) {
             case Modbus.READ_COILS:
                 ReadCoilsResponse rcResp = (ReadCoilsResponse) response;
@@ -239,9 +250,9 @@ public class ModbusClient {
         client.disconnect();
         log.info("Disconnected from MBS[{}]", serverName);
 
-        devices.stream().forEach((d)->{
-                gateway.onDeviceDisconnect(d.getName());
-                log.info("MBS[{}] disconnected MBD[{}]", serverName, d.getName());
+        devices.forEach((name, device)->{
+                gateway.onDeviceDisconnect(device.getName());
+                log.info("MBS[{}] disconnected MBD[{}]", serverName, name);
         });
     }
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusDeviceAware.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/ModbusDeviceAware.java
@@ -13,19 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.thingsboard.gateway.extensions.modbus;
 
-package org.thingsboard.gateway.extensions.modbus.conf.mapping;
-
-import lombok.Data;
-import org.thingsboard.gateway.extensions.common.conf.mapping.DataTypeMapping;
-import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
-
-@Data
-public class TagMapping {
-    private String tag;
-    private int functionCode;
-    private int address;
-    private int registerCount = ModbusExtensionConstants.DEFAULT_REGISTER_COUNT;
-    private String byteOrder = ModbusExtensionConstants.BIG_ENDIAN_BYTE_ORDER;
-    private int bit = ModbusExtensionConstants.NO_BIT_INDEX_DEFINED;
+public interface ModbusDeviceAware {
+    ModbusDevice getDevice(String deviceName);
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusExtensionConstants.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/ModbusExtensionConstants.java
@@ -34,4 +34,11 @@ public class ModbusExtensionConstants {
 
     public static final String LITTLE_ENDIAN_BYTE_ORDER = "LITTLE";
     public static final String BIG_ENDIAN_BYTE_ORDER = "BIG";
+
+    public static final int WORD_REGISTER_COUNT = 1;
+    public static final int INTEGER_REGISTER_COUNT = 2;
+    public static final int LONG_REGISTER_COUNT = 4;
+
+    public static final int FLOAT_REGISTER_COUNT = 2;
+    public static final int DOUBLE_REGISTER_COUNT = 4;
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/DeviceMapping.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/DeviceMapping.java
@@ -28,6 +28,6 @@ public class DeviceMapping {
     private String deviceName;
     private int attributesPollPeriod = ModbusExtensionConstants.DEFAULT_POLL_PERIOD;
     private int timeseriesPollPeriod = ModbusExtensionConstants.DEFAULT_POLL_PERIOD;
-    private List<TagMapping> attributes = Collections.emptyList(); // FIXME: Is it a real case, what device is without attributes?
-    private List<TagMapping> timeseries = Collections.emptyList(); // FIXME: Is it a real case, what device is without timeseries?
+    private List<PollingTagMapping> attributes = Collections.emptyList(); // FIXME: Is it a real case, what device is without attributes?
+    private List<PollingTagMapping> timeseries = Collections.emptyList(); // FIXME: Is it a real case, what device is without timeseries?
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/PollingTagMapping.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/PollingTagMapping.java
@@ -13,19 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.thingsboard.gateway.extensions.modbus.conf.mapping;
 
 import lombok.Data;
+import lombok.ToString;
 import org.thingsboard.gateway.extensions.common.conf.mapping.DataTypeMapping;
 import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
 
 @Data
-public class TagMapping {
-    private String tag;
-    private int functionCode;
-    private int address;
-    private int registerCount = ModbusExtensionConstants.DEFAULT_REGISTER_COUNT;
-    private String byteOrder = ModbusExtensionConstants.BIG_ENDIAN_BYTE_ORDER;
-    private int bit = ModbusExtensionConstants.NO_BIT_INDEX_DEFINED;
+@ToString(callSuper=true)
+public class PollingTagMapping extends TagMapping {
+    private int pollPeriod = ModbusExtensionConstants.NO_POLL_PERIOD_DEFINED;
+    private DataTypeMapping type;
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/TagValueMapping.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/mapping/TagValueMapping.java
@@ -13,18 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.thingsboard.gateway.extensions.modbus.conf.mapping;
 
 import lombok.Data;
-import org.thingsboard.gateway.extensions.common.conf.mapping.DataTypeMapping;
+import lombok.ToString;
 
 @Data
-public class DataMapping {
-    private String key;
-    private DataTypeMapping type;
-    private String functionCode;
-    private int address; //TODO: If we need hexadecimal value, the String type need to be used as it does for the function code.
-    private Boolean bigEndian = true;
-    private int registerCount = 1;
+@ToString(callSuper=true)
+public class TagValueMapping extends TagMapping {
+    private Object value;
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/rpc/RpcProcessor.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/rpc/RpcProcessor.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.gateway.extensions.modbus.rpc;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.ghgande.j2mod.modbus.Modbus;
+import com.ghgande.j2mod.modbus.ModbusException;
+import com.ghgande.j2mod.modbus.facade.AbstractModbusMaster;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.gateway.extensions.modbus.ModbusDevice;
+import org.thingsboard.gateway.extensions.modbus.ModbusDeviceAware;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.TagValueMapping;
+import org.thingsboard.gateway.extensions.modbus.util.ModbusUtils;
+import org.thingsboard.gateway.service.RpcCommandListener;
+import org.thingsboard.gateway.service.data.RpcCommandData;
+import org.thingsboard.gateway.service.data.RpcCommandResponse;
+import org.thingsboard.gateway.service.gateway.GatewayService;
+import org.thingsboard.gateway.util.JsonTools;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class RpcProcessor implements RpcCommandListener {
+    private static final String RESPONSE_STATUS_OK = "ok";
+    private static final String RESPONSE_FIELD_ERROR = "error";
+
+    private static final String RPC_WRITE = "write";
+
+    private final GatewayService gateway;
+    private final AbstractModbusMaster client;
+    private final ModbusDeviceAware deviceContainer;
+
+    public RpcProcessor(GatewayService gateway, AbstractModbusMaster client, ModbusDeviceAware deviceContainer) {
+        this.gateway = gateway;
+        this.client = client;
+        this.deviceContainer = deviceContainer;
+    }
+
+    @Override
+    public void onRpcCommand(String deviceName, RpcCommandData command) {
+        log.debug("RPC received: device='{}', command={}", deviceName, command);
+        ModbusDevice device = deviceContainer.getDevice(deviceName);
+        if (device == null) {
+            log.warn("No device '{}' found for RPC {}", deviceName, command);
+            gateway.onDeviceRpcResponse(createErrorResponse(command.getRequestId(),
+                                        deviceName,
+                                        String.format("No device '%s' found", deviceName)));
+            return;
+        }
+        if (!RPC_WRITE.equals(command.getMethod())) {
+            log.warn("Unknown RPC method '{}'", command.getMethod());
+            gateway.onDeviceRpcResponse(createErrorResponse(command.getRequestId(),
+                                                            deviceName,
+                                                            String.format("Unsupported RPC method '%s'", command.getMethod())));
+            return;
+        }
+
+        Map<String, String> results = new HashMap<>();
+        List<TagValueMapping> mappings = JsonTools.fromString(command.getParams(), new TypeReference<List<TagValueMapping>>(){});
+
+        for (TagValueMapping mapping : mappings) {
+            try {
+                switch (mapping.getFunctionCode()) {
+                    case Modbus.WRITE_COIL:
+                        log.trace("MBD[{}] executing 'write coil' for tag [{}]", device.getName(), mapping.getTag());
+                        client.writeCoil(device.getUnitId(), mapping.getAddress(), (Boolean) mapping.getValue());
+                        break;
+                    case Modbus.WRITE_SINGLE_REGISTER: {
+                        log.trace("MBD[{}] executing 'write single register' for tag [{}]", device.getName(), mapping.getTag());
+
+                        byte[] formattedBytes = ModbusUtils.formatLsbBytes(ModbusUtils.toBytes(mapping.getValue(),
+                                mapping.getRegisterCount()), mapping.getByteOrder());
+
+                        client.writeSingleRegister(device.getUnitId(), mapping.getAddress(), ModbusUtils.toRegisters(formattedBytes)[0]);
+                        break;
+                    }
+                    case Modbus.WRITE_MULTIPLE_REGISTERS: {
+                        log.trace("MBD[{}] executing 'write multiple register' for tag [{}]", device.getName(), mapping.getTag());
+
+                        byte[] formattedBytes;
+                        if (mapping.getValue() instanceof String) {
+                            formattedBytes = ModbusUtils.toBytes(mapping.getValue(), mapping.getRegisterCount());
+                        } else {
+                            formattedBytes = ModbusUtils.formatLsbBytes(
+                                    ModbusUtils.toBytes(mapping.getValue(), mapping.getRegisterCount()), mapping.getByteOrder());
+                        }
+                        client.writeMultipleRegisters(device.getUnitId(), mapping.getAddress(), ModbusUtils.toRegisters(formattedBytes));
+                        break;
+                    }
+                    default:
+                        throw new IllegalArgumentException("Unsupported Modbus function " + mapping.getFunctionCode());
+                }
+
+                results.put(mapping.getTag(), RESPONSE_STATUS_OK);
+                log.debug("MBD[{}] 'write multiple register' success for tag [{}], value [{}]",
+                                device.getName(), mapping.getTag(), mapping.getValue());
+            } catch (ModbusException e) {
+                log.warn("MBD[{}] failed to execute {} Modbus functions for tag [{}]",
+                            device.getName(), mapping.getFunctionCode(), mapping.getTag(), e);
+                results.put(mapping.getTag(), e.getMessage());
+            }
+        }
+
+        gateway.onDeviceRpcResponse(createResponse(command.getRequestId(), deviceName, results));
+    }
+
+    private RpcCommandResponse createErrorResponse(int requestId, String deviceName, String errorDescription) {
+        RpcCommandResponse response = new RpcCommandResponse();
+        response.setRequestId(requestId);
+        response.setDeviceName(deviceName);
+        Map<String, String> data = new HashMap<>();
+        data.put(RESPONSE_FIELD_ERROR, errorDescription);
+        response.setData(JsonTools.toString(data));
+        return response;
+    }
+
+    private RpcCommandResponse createResponse(int requestId, String deviceName, Map<String, String> data) {
+        RpcCommandResponse response = new RpcCommandResponse();
+        response.setRequestId(requestId);
+        response.setDeviceName(deviceName);
+        response.setData(JsonTools.toString(data));
+        return response;
+    }
+}

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/util/ModbusUtils.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/util/ModbusUtils.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright © 2017 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.gateway.extensions.modbus.util;
+
+import com.ghgande.j2mod.modbus.procimg.InputRegister;
+import com.ghgande.j2mod.modbus.procimg.Register;
+import com.ghgande.j2mod.modbus.procimg.SimpleRegister;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.jni.Poll;
+import org.thingsboard.gateway.extensions.modbus.conf.ModbusExtensionConstants;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.PollingTagMapping;
+import org.thingsboard.gateway.extensions.modbus.conf.mapping.TagMapping;
+import org.thingsboard.server.common.data.kv.*;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+@Slf4j
+public class ModbusUtils {
+
+    public static KvEntry convertToDataEntry(PollingTagMapping mapping, boolean value) {
+        KvEntry entry = null;
+
+        switch (mapping.getType().getDataType()) {
+            case STRING:
+                entry = new StringDataEntry(mapping.getTag(), Boolean.toString(value));
+                break;
+            case BOOLEAN:
+                entry = new BooleanDataEntry(mapping.getTag(), value);
+                break;
+            case DOUBLE:
+                entry = new DoubleDataEntry(mapping.getTag(), value ? 1. : 0.);
+                break;
+            case LONG:
+                entry = new LongDataEntry(mapping.getTag(), (long)(value ? 1 : 0));
+                break;
+            default:
+                log.error("Data type {} is not supported, tag [{}]", mapping.getType().getDataType(), mapping.getTag());
+                throw new IllegalArgumentException("Unsupported data type " + mapping.getType().getDataType());
+        }
+
+        return entry;
+    }
+
+    public static byte[] toBytes(Object value, int regCount) {
+        if (value instanceof Integer) {
+            return toBytes((Integer) value, regCount);
+        } else if (value instanceof Long) {
+            return toBytes((Long) value, regCount);
+        } else if (value instanceof Float) {
+            return toBytes((Float) value, regCount);
+        } else if (value instanceof Double) {
+            return toBytes((Double) value, regCount);
+        } else if (value instanceof Boolean) {
+            return toBytes((Boolean) value, regCount);
+        } else if (value instanceof String) {
+            return toBytes((String) value, regCount);
+        } else {
+            throw new IllegalArgumentException("Unexpected object type " + value.getClass());
+        }
+    }
+
+    public static byte[] toBytes(String value, int regCount) {
+        int maxSize = regCount * 2;
+        ByteBuffer buffer = ByteBuffer.allocate(maxSize)
+                                        .put(value.getBytes(), 0, Math.min(value.length(), maxSize));
+        int emptyBytesCount = maxSize - value.length();
+        for (int i = 0; i < emptyBytesCount; ++i) {
+            buffer.put((byte) 0);
+        }
+        return buffer.array();
+    }
+
+    public static byte[] toBytes(Float value, int regCount) {
+        return toBytes(Double.valueOf(value.doubleValue()), regCount);
+    }
+
+    public static byte[] toBytes(Double value, int regCount) {
+        ByteBuffer buffer = ByteBuffer.allocate(regCount * 2).order(ByteOrder.LITTLE_ENDIAN);
+        if (regCount == ModbusExtensionConstants.FLOAT_REGISTER_COUNT) {
+            buffer.putFloat(value.floatValue());
+        } else if (regCount == ModbusExtensionConstants.DOUBLE_REGISTER_COUNT) {
+            buffer.putDouble(value.doubleValue());
+        } else {
+            throw new IllegalArgumentException("Unexpected register count " + regCount);
+        }
+        return buffer.array();
+    }
+
+    public static byte[] toBytes(Integer value, int regCount) {
+        return toBytes(Long.valueOf(value.longValue()), regCount);
+    }
+
+    public static byte[] toBytes(Long value, int regCount) {
+        ByteBuffer buffer = ByteBuffer.allocate(regCount * 2).order(ByteOrder.LITTLE_ENDIAN);
+        if (regCount == ModbusExtensionConstants.WORD_REGISTER_COUNT) {
+            buffer.putShort(value.shortValue());
+        } else if (regCount == ModbusExtensionConstants.INTEGER_REGISTER_COUNT) {
+            buffer.putInt(value.intValue());
+        } else if (regCount == ModbusExtensionConstants.LONG_REGISTER_COUNT) {
+            buffer.putLong(value.longValue());
+        } else {
+            throw new IllegalArgumentException("Unexpected register count " + regCount);
+        }
+        return buffer.array();
+    }
+
+    public static byte[] formatLsbBytes(byte[] lsbData, String format) {
+        if (format.equalsIgnoreCase(ModbusExtensionConstants.LITTLE_ENDIAN_BYTE_ORDER)) {
+            return lsbData.clone();
+        }
+
+        byte[] formattedData = new byte[lsbData.length];
+        if (format.equalsIgnoreCase(ModbusExtensionConstants.BIG_ENDIAN_BYTE_ORDER)) {
+            for (int i = 0; i < formattedData.length; ++i) {
+                formattedData[i] = lsbData[formattedData.length - i - 1];
+            }
+        } else {
+            int foundMarkers = 0;
+
+            for (int i = 0; i < format.length(); ++i) {
+                char c = format.charAt(i);
+                int distance = -1;
+
+                if (Character.isDigit(c)) {
+                    distance = c - '0';
+                } else if (Character.isLetter(c)) {
+                    distance = Character.toLowerCase(c) - 'a';
+                }
+
+                if (distance >= 0 && lsbData.length > distance) {
+                    formattedData[foundMarkers] = lsbData[distance];
+                    foundMarkers++;
+                }
+            }
+
+            if (foundMarkers != formattedData.length) {
+                throw new IllegalArgumentException(String.format("Wrong byte format '%s'", format));
+            }
+        }
+
+        return formattedData;
+    }
+
+    public static Register[] toRegisters(byte[] data) {
+        SimpleRegister[] registers = new SimpleRegister[data.length / 2];
+        for (int i = 0; i < registers.length; ++i) {
+            registers[i] = new SimpleRegister(data[i * 2], data[i * 2 + 1]);
+        }
+        return registers;
+    }
+
+    public static byte[] convertToLsbOrder(InputRegister[] data, String format) {
+        byte[] outputBuf = new byte[data.length * 2];
+
+        if (format.equalsIgnoreCase(ModbusExtensionConstants.LITTLE_ENDIAN_BYTE_ORDER)) {
+            for (int i = 0; i < outputBuf.length; ++i) {
+                outputBuf[i] = data[i / 2].toBytes()[i % 2];
+            }
+            return outputBuf;
+        } else if (format.equalsIgnoreCase(ModbusExtensionConstants.BIG_ENDIAN_BYTE_ORDER)) {
+            for (int i = outputBuf.length - 1; i >= 0; --i) {
+                outputBuf[outputBuf.length - i - 1] = data[i / 2].toBytes()[i % 2];
+            }
+            return outputBuf;
+        }
+
+        int length = format.length();
+        int foundMarkers = 0;
+
+        for (int i = 0; i < length; ++i) {
+            char c = format.charAt(i);
+            int distance = -1;
+
+            if (Character.isDigit(c)) {
+                distance = c - '0';
+            } else if (Character.isLetter(c)) {
+                distance = Character.toLowerCase(c) - 'a';
+            }
+
+            if (distance >= 0 && outputBuf.length > distance) {
+                outputBuf[distance] = data[foundMarkers / 2].toBytes()[foundMarkers % 2];
+                foundMarkers++;
+            }
+        }
+
+        if (foundMarkers != outputBuf.length) {
+            return null;
+        }
+
+        return outputBuf;
+    }
+
+    public static KvEntry convertToDataEntry(PollingTagMapping mapping, InputRegister[] data) {
+        KvEntry entry = null;
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(convertToLsbOrder(data, mapping.getByteOrder()));
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+
+        switch (mapping.getType().getDataType()) {
+            case BOOLEAN:
+                if (ModbusExtensionConstants.MIN_BIT_INDEX_IN_REG > mapping.getBit() || mapping.getBit() > ModbusExtensionConstants.MAX_BIT_INDEX_IN_REG) {
+                    log.error("Wrong bit index {}, tag [{}]", mapping.getBit(), mapping.getTag());
+                    throw new IllegalArgumentException("Bit index is out of range, value " + mapping.getBit());
+                }
+
+                entry = new BooleanDataEntry(mapping.getTag(), ((byteBuffer.getShort() >> mapping.getBit()) & 1) == 1);
+                break;
+            case STRING:
+                entry = new StringDataEntry(mapping.getTag(), new String(byteBuffer.array()));
+                break;
+            case DOUBLE:
+                double doubleNumber = mapping.getRegisterCount() <= 2 ? byteBuffer.getFloat() : byteBuffer.getDouble();
+                entry = new DoubleDataEntry(mapping.getTag(), doubleNumber);
+                break;
+            case LONG:
+                long longNumber = 0;
+                switch (mapping.getRegisterCount()) {
+                    case 1:
+                        longNumber = byteBuffer.getShort();
+                        break;
+                    case 2:
+                        longNumber = byteBuffer.getInt();
+                        break;
+                    case 4:
+                        longNumber = byteBuffer.getLong();
+                        break;
+                }
+                entry = new LongDataEntry(mapping.getTag(), longNumber);
+                break;
+            default:
+                log.error("Data type {} is not supported, tag [{}]", mapping.getType().getDataType(), mapping.getTag());
+                throw new IllegalArgumentException("Unsupported data type " + mapping.getType().getDataType());
+        }
+
+        return entry;
+    }
+}

--- a/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
+++ b/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
@@ -473,7 +473,7 @@ public class MqttGatewayService implements GatewayService, MqttHandler, MqttClie
             RpcCommandData rpcCommand = new RpcCommandData();
             rpcCommand.setRequestId(data.get("id").asInt());
             rpcCommand.setMethod(data.get("method").asText());
-            rpcCommand.setParams(JsonTools.toString(data.get("params")));
+            rpcCommand.setParams(data.get("params").asText());
             listeners.forEach(listener -> callbackExecutor.submit(() -> {
                 try {
                     listener.onRpcCommand(deviceName, rpcCommand);

--- a/src/main/java/org/thingsboard/gateway/util/JsonTools.java
+++ b/src/main/java/org/thingsboard/gateway/util/JsonTools.java
@@ -16,6 +16,7 @@
 package org.thingsboard.gateway.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -51,9 +52,25 @@ public class JsonTools {
         }
     }
 
+    public static <T> T fromString(String data, TypeReference<T> type) {
+        try {
+            return JSON.readValue(data, type);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static String toString(JsonNode node) {
         try {
             return JSON.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String toString(Map<String, String> map) {
+        try {
+            return JSON.writeValueAsString(map);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Also fix the case when Modbus device that has the atribute and telemetry item with the same name cannot save both of them but only atribute.