### PR TITLE
Fixed MODBUS first connection failure without attempting connection

### DIFF
--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusIpTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusIpTransportConfiguration.java
@@ -24,4 +24,9 @@ public class ModbusIpTransportConfiguration implements ModbusTransportConfigurat
     private String host;
     private int port = ModbusExtensionConstants.DEFAULT_MODBUS_TCP_PORT;
     private int timeout = ModbusExtensionConstants.DEFAULT_SOCKET_TIMEOUT;
+
+    @Override
+    public long getRetryInterval() {
+        return timeout;
+    }
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusRtuTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusRtuTransportConfiguration.java
@@ -28,4 +28,9 @@ public class ModbusRtuTransportConfiguration implements ModbusTransportConfigura
     private int dataBits;
     private float stopBits;
     private String parity;
+
+    @Override
+    public long getRetryInterval() {
+        return timeout;
+    }
 }

--- a/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusTransportConfiguration.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/modbus/conf/transport/ModbusTransportConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
  package org.thingsboard.gateway.extensions.modbus.conf.transport;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -31,5 +31,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = ModbusUdpTransportConfiguration.class, name = "udp"),
         @JsonSubTypes.Type(value = ModbusRtuTransportConfiguration.class, name = "rtu")})
 public interface ModbusTransportConfiguration {
-
+    /**
+     * 获取尝试周期时间
+     *
+     * @return
+     */
+    long getRetryInterval();
 }


### PR DESCRIPTION
I found that when the Modbus service disconnects from the start gateway, it only tries to connect once, and when the Modbus service starts, it does not automatically connect.
I modified the connection logic following mqtt's retry method