### PR TITLE
Update MqttGatewayService.java

### DIFF
--- a/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
+++ b/src/main/java/org/thingsboard/gateway/service/gateway/MqttGatewayService.java
@@ -474,7 +474,7 @@ public class MqttGatewayService implements GatewayService, MqttHandler, MqttClie
             RpcCommandData rpcCommand = new RpcCommandData();
             rpcCommand.setRequestId(data.get("id").asInt());
             rpcCommand.setMethod(data.get("method").asText());
-            rpcCommand.setParams(data.get("params").asText());
+            rpcCommand.setParams(data.get("params").toString());
             listeners.forEach(listener -> callbackExecutor.submit(() -> {
                 try {
                     listener.onRpcCommand(deviceName, rpcCommand);


### PR DESCRIPTION
the params filed in payload is an json array, so can't be parsed as string, we need to deserialization params to String by using toString() not asText();