### PR TITLE
improved the usage of docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,3 +20,10 @@ ADD run-application.sh /run-application.sh
 ADD tb-gateway.deb /tb-gateway.deb
 
 RUN chmod +x /run-application.sh
+RUN dpkg -i --force-all /tb-gateway.deb
+RUN mkdir -p /var/log/tb-gateway/
+RUN mkdir -p /usr/share/tb-gateway/conf/
+
+RUN touch /var/log/tb-gateway/tb-gateway.log
+
+CMD ./run-application.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,4 +24,3 @@ services:
       - GATEWAY_HOST=${GATEWAY_HOST}
     ports:
       - "9090:9090"
-    entrypoint: /run-application.sh

--- a/docker/run-application.sh
+++ b/docker/run-application.sh
@@ -15,16 +15,11 @@
 # limitations under the License.
 #
 
-dpkg -i /tb-gateway.deb
-
 # Copying env variables into conf files
 printenv | awk -F "=" '{print "export " $1 "='\''" $2 "'\''"}' >> /usr/share/tb-gateway/conf/tb-gateway.conf
 
 cat /usr/share/tb-gateway/conf/tb-gateway.conf
 
 echo "Starting 'TB-gateway' service..."
-service tb-gateway start
 
-# Wait until log file is created
-sleep 5
-tail -f /var/log/tb-gateway/tb-gateway.log
+java -jar /opt/biot/tb_test/tb-gateway/bin/tb-gateway.jar


### PR DESCRIPTION
    - dpkg installation is executed on image build now
    - the jar is executed in front so the logging is available via docker log
    - no warning messages about missing openjdk