### PR TITLE
fix null reference error. 

### DIFF
--- a/src/main/java/org/thingsboard/gateway/extensions/mqtt/client/conf/mapping/MqttJsonConverter.java
+++ b/src/main/java/org/thingsboard/gateway/extensions/mqtt/client/conf/mapping/MqttJsonConverter.java
@@ -57,7 +57,7 @@ public class MqttJsonConverter extends BasicJsonConverter implements MqttDataCon
         String data = new String(msg.getPayload(), StandardCharsets.UTF_8);
         log.trace("Parsing json message: {}", data);
 
-        if (!filterExpression.isEmpty()) {
+        if (filterExpression != null && !filterExpression.isEmpty()) {
             try {
                 log.debug("Data before filtering {}", data);
                 DocumentContext document = JsonPath.parse(data);


### PR DESCRIPTION
When use remote config, the field "filterExpression" generated from ui should use some valid string or an empty space, if not ,this will be null. But if user does not want to use this, the empty space will be forgot to set. So we should check it here.