### PR TITLE
Added value parsing and posting depending on tag

### DIFF
--- a/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
+++ b/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
@@ -28,7 +28,7 @@ class BytesModbusUplinkConverter(ModbusConverter):
         for config_data in data:
             if self.__result.get(config_data) is None:
                 self.__result[config_data] = []
-            for tag in data[config_data]:
+            for tag_indx, tag in enumerate(data[config_data]):
                 data_sent = data[config_data][tag]["data_sent"]
                 input_data = data[config_data][tag]["input_data"]
                 log.debug("Called convert function from %s with args", self.__class__.__name__)
@@ -48,9 +48,9 @@ class BytesModbusUplinkConverter(ModbusConverter):
                     reg_count = data_sent.get("registerCount", 1)
                     type_of_data = data_sent["type"]
                     if byte_order == "LITTLE":
-                        decoder = BinaryPayloadDecoder.fromRegisters(result, byteorder=Endian.Little)
+                        decoder = BinaryPayloadDecoder.fromRegisters([result[tag_indx]], byteorder=Endian.Little)
                     elif byte_order == "BIG":
-                        decoder = BinaryPayloadDecoder.fromRegisters(result, byteorder=Endian.Big)
+                        decoder = BinaryPayloadDecoder.fromRegisters([result[tag_indx]], byteorder=Endian.Big)
                     else:
                         log.warning("byte order is not BIG or LITTLE")
                         continue

--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -154,8 +154,12 @@ class TBGatewayService:
                                                "current_event",
                                                current_event["deviceName"])
                         if current_event.get("telemetry"):
-                            data_to_send = loads('{"ts": %f,"values": %s}' % (int(time.time()*1000),
-                                                                              ','.join(dumps(param) for param in current_event["telemetry"])))
+                            items = []
+                            for param in current_event["telemetry"]:
+                                for key in param:
+                                    items.append("\"" + str(key) + "\"" + ":" + str(param[key]))
+                            telemetry = "{" + ' , '.join(items) + "}"
+                            data_to_send = loads('{"ts": %f,"values": %s}' % (int(time.time()*1000), telemetry))
                             self.__published_events.append(self.tb_client.client.gw_send_telemetry(current_event["deviceName"],
                                                                                                    data_to_send))
                         if current_event.get("attributes"):


### PR DESCRIPTION
I was not able to post values from this setup:

https://gist.github.com/Sliosas/73022f887a591dcfb8d0c74dde2931ac

to thingsboard-server. The problem is that i have a modbus device that returns two values in one response (modbus tcp response example):

b'\x00\x01\x00\x00\x00\x07\x01\x04\x04\x00\x34\x00\x44'

however thingsboard uses only the first value for both (Windspeed and Direction) timeseries tags and then fails to create a correct json object for the telemetry key.

Am i using a bad mobus.json configuration, is it not possible to return multiple values in one call, or is it a real issue?