### PR TITLE
Fix 'Cannot find convert' error when no extension is defined in mqtt converter

### DIFF
--- a/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
+++ b/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
@@ -240,7 +240,11 @@ class MqttConnector(Connector, Thread):
                     # Load converter for this mapping entry ------------------------------------------------------------
                     # mappings are guaranteed to have topicFilter and converter fields. See __init__
                     converter_type = mapping["converter"]["type"]
-                    converter_extension = mapping["converter"]["extension"]
+
+                    # extension is optional
+                    converter_extension = None
+                    if "extension" in mapping["converter"]:
+                        converter_extension = mapping["converter"]["extension"]
 
                     if converter_type:
                         if converter_extension:
@@ -252,6 +256,9 @@ class MqttConnector(Connector, Thread):
                             else:
                                 self.__log.error("\n\nCannot find extension module for %s topic."
                                                  "\nPlease check your configuration.\n", mapping["topicFilter"])
+                        else:
+                            # if extension is not specified, use json converter
+                            converter = JsonMqttUplinkConverter(mapping)
                     else:
                         converter = JsonMqttUplinkConverter(mapping)
 


### PR DESCRIPTION
During my test, I encountered the following error messages

`""2020-04-10 19:27:24" - ERROR - [mqtt_connector.py] - mqtt_connector - 266 - Cannot find converter for /sensor/data topic"
""2020-04-10 19:27:24" - ERROR - [mqtt_connector.py] - mqtt_connector - 266 - Cannot find converter for /sensor/+/data topic"`

After some investigation, I noticed it's because there is no extension defined in some mqtt converters in mqtt.json which leads to no converter being created. 