### PR TITLE
fix copy command

### DIFF
--- a/for_build/etc/thingsboard-gateway/config/ble.json
+++ b/for_build/etc/thingsboard-gateway/config/ble.json
@@ -8,6 +8,7 @@
         {
             "name": "Temperature and humidity sensor",
             "MACAddress": "4C:65:A8:DF:85:C0",
+            "addrType": "public",
             "telemetry": [
                 {
                     "key": "temperature",

--- a/for_build/etc/thingsboard-gateway/config/mqtt.json
+++ b/for_build/etc/thingsboard-gateway/config/mqtt.json
@@ -3,6 +3,7 @@
     "name":"Default Local Broker",
     "host":"127.0.0.1",
     "port":1883,
+    "clientId": "ThingsBoard_gateway",
     "security": {
       "type": "basic",
       "username": "user",

--- a/for_build/etc/thingsboard-gateway/config/request.json
+++ b/for_build/etc/thingsboard-gateway/config/request.json
@@ -13,6 +13,10 @@
       "httpHeaders": {
         "ACCEPT": "application/json"
       },
+      "content": {
+        "name": "morpheus",
+        "job": "leader"
+      },
       "allowRedirects": true,
       "timeout": 0.5,
       "scanPeriod": 5,

--- a/for_build/etc/thingsboard-gateway/config/rest.json
+++ b/for_build/etc/thingsboard-gateway/config/rest.json
@@ -3,8 +3,8 @@
   "port": "5000",
   "mapping":[
     {
-      "endpoint": "/test_device",
-      "HTTPMethod": [
+      "endpoint": "/device1",
+      "HTTPMethods": [
         "POST"
       ],
       "security":
@@ -27,21 +27,20 @@
         "timeseries": [
           {
             "type": "double",
-            "key": "temperature",
+            "key": "${sensorModel}",
             "value": "${temp}"
           },
           {
             "type": "double",
             "key": "humidity",
-            "value": "${hum}",
-            "converter": "CustomConverter"
+            "value": "${hum}"
           }
         ]
       }
     },
     {
-      "endpoint": "/test",
-      "HTTPMethod": [
+      "endpoint": "/anon1",
+      "HTTPMethods": [
         "GET",
         "POST"
       ],
@@ -50,8 +49,7 @@
         "type": "anonymous"
       },
       "converter": {
-        "type": "custom",
-        "class": "CustomConverter",
+        "type": "json",
         "deviceNameExpression": "Device 2",
         "deviceTypeExpression": "default",
         "attributes": [
@@ -73,6 +71,81 @@
             "value": "${hum}"
           }
         ]
+      }
+    },
+    {
+      "endpoint": "/anon2",
+      "HTTPMethods": [
+        "POST"
+      ],
+      "security":
+      {
+        "type": "anonymous"
+      },
+      "converter": {
+        "type": "custom",
+        "deviceNameExpression": "SuperAnonDevice",
+        "deviceTypeExpression": "default",
+        "extension": "CustomRestUplinkConverter",
+        "extension-config": [
+          {
+          "key": "Totaliser",
+          "datatype": "float",
+          "fromByte": 0,
+          "toByte": 4,
+          "byteorder": "big",
+          "signed": true,
+          "multiplier": 1
+          }]
+      }
+    }
+  ],
+  "attributeUpdates": [
+      {
+        "HTTPMethod": "POST",
+        "SSLVerify": false,
+        "httpHeaders": {
+          "CONTENT-TYPE": "application/json"
+        },
+        "security": {
+          "type": "basic",
+          "username": "user",
+          "password": "passwd"
+        },
+        "timeout": 0.5,
+        "tries": 3,
+        "allowRedirects": true,
+        "deviceNameFilter": ".*REST$",
+        "attributeFilter": "data",
+        "requestUrlExpression": "sensor/${deviceName}/${attributeKey}",
+        "valueExpression": "{\"${attributeKey}\":\"${attributeValue}\"}"
+      }
+  ],
+  "serverSideRpc": [
+    {
+      "deviceNameFilter": ".*",
+      "methodFilter": "echo",
+      "requestUrlExpression": "http://127.0.0.1:5001/${deviceName}",
+      "responseTimeout": 1,
+      "HTTPMethod": "GET",
+      "valueExpression": "${params}",
+      "timeout": 0.5,
+      "tries": 3,
+      "httpHeaders": {
+        "Content-Type": "application/json"
+      },
+      "security": {
+        "type": "anonymous"
+      }
+    },
+    {
+      "deviceNameFilter": ".*",
+      "methodFilter": "no-reply",
+      "requestUrlExpression": "sensor/${deviceName}/request/${methodName}/${requestId}",
+      "HTTPMethod": "POST",
+      "valueExpression": "${params}",
+      "httpHeaders": {
+        "Content-Type": "application/json"
       }
     }
   ]

--- a/for_build/etc/thingsboard-gateway/config/snmp.json
+++ b/for_build/etc/thingsboard-gateway/config/snmp.json
@@ -1,0 +1,138 @@
+{
+  "devices": [
+    {
+      "deviceName": "SNMP router",
+      "deviceType": "snmp",
+      "ip": "snmp.live.gambitcommunications.com",
+      "port": 161,
+      "pollPeriod": 5000,
+      "community": "public",
+      "attributes": [
+        {
+          "key": "ReceivedFromGet",
+          "method": "get",
+          "oid": "1.3.6.1.2.1.1.1.0",
+          "timeout": 6
+        },
+        {
+          "key": "ReceivedFromMultiGet",
+          "method": "multiget",
+          "oid": [
+            "1.3.6.1.2.1.1.1.0",
+            "1.3.6.1.2.1.1.2.0"
+          ],
+          "timeout": 6
+        },
+        {
+          "key": "ReceivedFromGetNext",
+          "method": "getnext",
+          "oid": "1.3.6.1.2.1.1.1.0",
+          "timeout": 6
+        },
+        {
+          "key": "ReceivedFromMultiWalk",
+          "method": "multiwalk",
+          "oid": [
+            "1.3.6.1.2.1.1.1.0",
+            "1.3.6.0.1.2.1"
+          ]
+        },
+        {
+          "key": "ReceivedFromBulkWalk",
+          "method": "bulkwalk",
+          "oid": [
+            "1.3.6.1.2.1.1.1.0",
+            "1.3.6.1.2.1.1.2.0"
+          ]
+        },
+        {
+          "key": "ReceivedFromBulkGet",
+          "method": "bulkget",
+          "scalarOid": [
+            "1.3.6.1.2.1.1.1.0",
+            "1.3.6.1.2.1.1.2.0"
+          ],
+          "repeatingOid": [
+            "1.3.6.1.2.1.1.1.0",
+            "1.3.6.1.2.1.1.2.0"
+          ],
+          "maxListSize": 10
+        }
+      ],
+      "telemetry": [
+        {
+          "key": "ReceivedFromWalk",
+          "community": "private",
+          "method": "walk",
+          "oid": "1.3.6.1.2.1.1.1.0"
+        },
+        {
+          "key": "ReceivedFromTable",
+          "method": "table",
+          "oid": "1.3.6.1.2.1.1"
+        }
+      ],
+      "attributeUpdateRequests": [
+        {
+          "attributeFilter": "dataToSet",
+          "method": "set",
+          "oid": "1.3.6.1.2.1.1.1.0"
+        },
+        {
+          "attributeFilter": "dataToMultiSet",
+          "method": "multiset",
+          "mappings": {
+            "1.2.3": "10",
+            "2.3.4": "${attribute}"
+          }
+        }
+      ],
+      "serverSideRpcRequests": [
+        {
+          "requestFilter": "setData",
+          "method": "set",
+          "oid": "1.3.6.1.2.1.1.1.0"
+        },
+        {
+          "requestFilter": "multiSetData",
+          "method": "multiset"
+        },
+        {
+          "requestFilter": "getData",
+          "method": "get",
+          "oid": "1.3.6.1.2.1.1.1.0"
+        },
+        {
+          "requestFilter": "runBulkWalk",
+          "method": "bulkwalk",
+          "oid": [
+            "1.3.6.1.2.1.1.1.0",
+            "1.3.6.1.2.1.1.2.0"
+          ]
+        }
+      ]
+    },
+    {
+      "deviceName": "SNMP router",
+      "deviceType": "snmp",
+      "ip": "127.0.0.1",
+      "pollPeriod": 5000,
+      "community": "public",
+      "converter": "CustomSNMPConverter",
+      "attributes": [
+        {
+          "key": "ReceivedFromGetWithCustomConverter",
+          "method": "get",
+          "oid": "1.3.6.1.2.1.1.1.0"
+        }
+      ],
+      "telemetry": [
+        {
+          "key": "ReceivedFromTableWithCustomConverter",
+          "method": "table",
+          "oid": "1.3.6.1.2.1.1.1.0"
+        }
+      ]
+    }
+  ]
+}

--- a/for_build/etc/thingsboard-gateway/config/tb_gateway.yaml
+++ b/for_build/etc/thingsboard-gateway/config/tb_gateway.yaml
@@ -1,9 +1,11 @@
 thingsboard:
   host: demo.thingsboard.io
   port: 1883
+  remoteShell: false
   remoteConfiguration: false
   security:
     accessToken: PUT_YOUR_GW_ACCESS_TOKEN_HERE
+  qos: 1
 storage:
   type: memory
   read_records_count: 100
@@ -14,7 +16,6 @@ storage:
 #  max_read_records_count: 10
 #  max_records_per_file: 10000
 connectors:
-
   -
     name: MQTT Broker Connector
     type: mqtt
@@ -59,6 +60,16 @@ connectors:
 #    name: ODBC Connector
 #    type: odbc
 #    configuration: odbc.json
+#
+#  -
+#    name: REST Connector
+#    type: rest
+#    configuration: rest.json
+#
+#  -
+#    name: SNMP Connector
+#    type: snmp
+#    configuration: snmp.json
 #
 #  -
 #    name: Custom Serial Connector

--- a/generate_deb_package.sh
+++ b/generate_deb_package.sh
@@ -30,8 +30,8 @@ if [ "$1" != "only_clean" ] ; then
   echo "Creating sources for DEB package..."
   python3 setup.py --command-packages=stdeb.command bdist_deb
   echo "Adding the files, scripts and permissions in the package"
-  sudo cp -r thingsboard_gateway/extensions for_build/etc/thingsboard-gateway/extensions
-  sudo cp -r thingsboard_gateway/config for_build/etc/thingsboard-gateway/config
+  sudo cp -r thingsboard_gateway/extensions for_build/etc/thingsboard-gateway/
+  sudo cp -r thingsboard_gateway/config for_build/etc/thingsboard-gateway/
   sudo cp -r for_build/etc deb_dist/thingsboard-gateway-$CURRENT_VERSION/debian/python3-thingsboard-gateway
   sudo cp -r for_build/var deb_dist/thingsboard-gateway-$CURRENT_VERSION/debian/python3-thingsboard-gateway
   sudo cp -r -a for_build/DEBIAN deb_dist/thingsboard-gateway-$CURRENT_VERSION/debian/python3-thingsboard-gateway


### PR DESCRIPTION
when i run `sudo ./generate_deb_package.sh` command to generate .deb file, 
`sudo cp -r thingsboard_gateway/extensions for_build/etc/thingsboard-gateway/extension` command creates another extension folder in **for_build/etc/thingsboard-gateway/extensions** . ->  **for_build/etc/thingsboard-gateway/extensions/extensions**

Also this sitiuation is same for copying config folder command:  `sudo cp -r thingsboard_gateway/command for_build/etc/thingsboard-gateway/command`

I fixed these two copy command and update latest config files under **for_build** folder. This issue may not occur on your platform. So, this may an unnecessary pull request.


OS : Ubuntu 20.04.1 LTS