### PR TITLE
don't call constructor if the connector is not loaded

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -300,11 +300,14 @@ class TBGatewayService:
                     connector = None
                     try:
                         if connector_config["config"][config] is not None:
-                            connector = self._implemented_connectors[connector_type](self, connector_config["config"][config],
-                                                                                     connector_type)
-                            connector.setName(connector_config["name"])
-                            self.available_connectors[connector.get_name()] = connector
-                            connector.open()
+                            if self._implemented_connectors[connector_type]:
+                                connector = self._implemented_connectors[connector_type](self, connector_config["config"][config],
+                                                                                        connector_type)
+                                connector.setName(connector_config["name"])
+                                self.available_connectors[connector.get_name()] = connector
+                                connector.open()
+                            else:
+                                log.warning("Connector implementation not found for %s", connector_config["name"])
                         else:
                             log.info("Config not found for %s", connector_type)
                     except Exception as e:


### PR DESCRIPTION
don't call constructor if the connector is not loaded, log a warning instead