### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,9 @@ ENV logs /thingsboard_gateway/logs
 RUN apt-get update && apt-get install gcc python3-dev build-essential protobuf-compiler -y
 # The default grpcio version of 1.43.0 was broken on ARM v7
 # See this thread: https://groups.google.com/g/grpc-io/c/vjbL3IdZ2Vk?pli=1
-RUN pip install grpcio==1.40.0
-RUN python3 -m pip install --upgrade pip --user && python3 -m pip install --upgrade setuptools && pip3 install importlib_metadata --user
+RUN pip install --no-cache-dir grpcio==1.40.0
+RUN python3 -m pip install --no-cache-dir --upgrade pip --user && python3 -m pip install --no-cache-dir --upgrade setuptools && pip3 install --no-cache-dir importlib_metadata --user
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 RUN python /setup.py install && mkdir -p /default-config/config /default-config/extensions/ && cp -r /thingsboard_gateway/config/* /default-config/config/ && cp -r /thingsboard_gateway/extensions/* /default-config/extensions
 VOLUME ["${configs}", "${extensions}", "${logs}"]
 CMD [ "/bin/sh", "./start-gateway.sh" ]

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,13 @@
+jsonpath-rw
+regex
+pip
+paho-mqtt
+PyYAML
+simplejson
+requests
+PyInquirer
+pyfiglet
+termcolor
+grpcio
+protobuf
+cachetools


### PR DESCRIPTION
created a "requirements.txt" file mentioning required dependencies and
further installing dependencies using pip way with "--no-cache-dir" flag.

further, using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik raj <rajpratik71@gmail.com>