### PR TITLE
Update modbus_connector.py to solve the issue related with "missing 1 required positional argument: 'values'"

### DIFF
--- a/thingsboard_gateway/connectors/modbus/modbus_connector.py
+++ b/thingsboard_gateway/connectors/modbus/modbus_connector.py
@@ -292,9 +292,13 @@ class ModbusConnector(Connector, threading.Thread):
             result = self.__available_functions[function_code](config["address"],
                                                                config.get("objectsCount", config.get("registersCount",  config.get("registerCount", 1))),
                                                                unit=unit_id)
-        elif function_code in (5, 6, 15, 16):
-            result = self.__available_functions[function_code](config["address"],
-                                                               config["payload"],
+        elif function_code in (5, 6):
+            result = self.__available_functions[function_code](address=config["address"],
+                                                               value=config["payload"],
+                                                               unit=unit_id)
+        elif function_code in (15, 16):
+            result = self.__available_functions[function_code](address=config["address"],
+                                                               values=config["payload"],
                                                                unit=unit_id)
         else:
             log.error("Unknown Modbus function with code: %i", function_code)


### PR DESCRIPTION
Added extra call to __available_functions so that when changing multiple registers using modbus function_code 15 or 16, the code uses "values" (line 301)  instead of "value" (line 297)