### PR TITLE
Update to fix and Update "SendDataOnlyOnChange" behaviour

### DIFF
--- a/thingsboard_gateway/connectors/modbus/modbus_connector.py
+++ b/thingsboard_gateway/connectors/modbus/modbus_connector.py
@@ -179,22 +179,22 @@ class ModbusConnector(Connector, threading.Thread):
                                     # self.__gateway.send_to_storage(self.get_name(), to_send)
                                     # self.statistics['MessagesSent'] += 1
                                     log.debug("Data has not been changed.")
-                            elif converted_data and self.__devices[device]["config"].get("sendDataOnlyOnChange") is None or not self.__devices[device]["config"].get("sendDataOnlyOnChange"):
-                                self.statistics['MessagesReceived'] += 1
-                                to_send = {"deviceName": converted_data["deviceName"],
-                                           "deviceType": converted_data["deviceType"]}
-                                # if converted_data["telemetry"] != self.__devices[device]["telemetry"]:
-                                self.__devices[device]["last_telemetry"] = converted_data["telemetry"]
-                                to_send["telemetry"] = converted_data["telemetry"]
-                                # if converted_data["attributes"] != self.__devices[device]["attributes"]:
-                                self.__devices[device]["last_attributes"] = converted_data["attributes"]
-                                to_send["attributes"] = converted_data["attributes"]
-                                # self.__gateway.send_to_storage(self.get_name(), to_send)
-                                # self.statistics['MessagesSent'] += 1
+                        elif converted_data and self.__devices[device]["config"].get("sendDataOnlyOnChange") is None or not self.__devices[device]["config"].get("sendDataOnlyOnChange"):
+                            self.statistics['MessagesReceived'] += 1
+                            to_send = {"deviceName": converted_data["deviceName"],
+                                       "deviceType": converted_data["deviceType"]}
+                            # if converted_data["telemetry"] != self.__devices[device]["telemetry"]:
+                            self.__devices[device]["last_telemetry"] = converted_data["telemetry"]
+                            to_send["telemetry"] = converted_data["telemetry"]
+                            # if converted_data["attributes"] != self.__devices[device]["attributes"]:
+                            self.__devices[device]["last_attributes"] = converted_data["attributes"]
+                            to_send["attributes"] = converted_data["attributes"]
+                            # self.__gateway.send_to_storage(self.get_name(), to_send)
+                            # self.statistics['MessagesSent'] += 1
 
-                if to_send.get("attributes") or to_send.get("telemetry"):
-                    self.__gateway.send_to_storage(self.get_name(), to_send)
-                    self.statistics['MessagesSent'] += 1
+                    if to_send.get("attributes") or to_send.get("telemetry"):
+                        self.__gateway.send_to_storage(self.get_name(), to_send)
+                        self.statistics['MessagesSent'] += 1
             except ConnectionException:
                 time.sleep(5)
                 log.error("Connection lost! Reconnecting...")

--- a/thingsboard_gateway/connectors/modbus/modbus_connector.py
+++ b/thingsboard_gateway/connectors/modbus/modbus_connector.py
@@ -140,16 +140,19 @@ class ModbusConnector(Connector, threading.Thread):
                             log.debug("Checking %s for device %s", config_data, device)
                             self.__devices[device]["next_"+config_data+"_check"] = current_time + self.__devices[device]["config"][config_data+"PollPeriod"]/1000
                             log.debug(device_responses)
-                            converted_data = {}
-                            try:
-                                converted_data = self.__devices[device]["converter"].convert(config={**self.__devices[device]["config"],
-                                                                                                     "byteOrder": self.__devices[device]["config"].get("byteOrder", self.__byte_order),
-                                                                                                     "wordOrder": self.__devices[device]["config"].get("wordOrder", self.__word_order)},
-                                                                                             data=device_responses)
-                            except Exception as e:
-                                log.error(e)
+                        converted_data = {}
+                        try:
+                            converted_data = self.__devices[device]["converter"].convert(config={**self.__devices[device]["config"],
+                                                                                                 "byteOrder": self.__devices[device]["config"].get("byteOrder", self.__byte_order),
+                                                                                                 "wordOrder": self.__devices[device]["config"].get("wordOrder", self.__word_order)},
+                                                                                         data=device_responses)
+                        except Exception as e:
+                            log.error(e)
 
-                            if converted_data and self.__devices[device]["config"].get("sendDataOnlyOnChange"):
+                        if converted_data and self.__devices[device]["config"].get("sendDataOnlyOnChange"):
+                            if current_data["sendDataOnlyOnChange"] == False:
+                                pass
+                            else:
                                 self.statistics['MessagesReceived'] += 1
                                 to_send = {"deviceName": converted_data["deviceName"], "deviceType": converted_data["deviceType"]}
                                 if to_send.get("telemetry") is None:


### PR DESCRIPTION
- This pull request will overwrite a previous pending pull request: "resolve bug for timeseries in modbus when sendDataOnlyOnChange is active #477"
- SendDataOnlyOnChange logic update:
    -- Code changes fix the "SendDataOnlyOnChange" bug for telemetry data.
    -- Code changes to allow including "SendDataOnlyOnChange" parameter within each variable. 
    -- This version allows to define a general value of "SendDataOnlyOnChange" and in addition a particular behaviour of "SendDataOnlyOnChange" for particular variables, i.e. we can define "SendDataOnlyOnChange" as True for all the variables and then if there is a variable where we need to set "SendDataOnlyOnChange" to False it can be included as a parameter within such variable (attribute or telemetry) in the configuration Json.