### PR TITLE
Bugfix: validation always fails: 'str' object has no attribute 'get'

### DIFF
--- a/thingsboard_gateway/tb_utility/tb_utility.py
+++ b/thingsboard_gateway/tb_utility/tb_utility.py
@@ -43,8 +43,26 @@ class TBUtility:
             error = 'deviceName is empty in data: '
         if error is None and not data.get("deviceType"):
             error = 'deviceType is empty in data: '
-        if error is None and data.get("attributes") is None and (data.get("telemetry") is None or (data["telemetry"].get("ts") is not None and len(data["telemetry"].get("values")) == 0)):
-            error = 'No telemetry and attributes in data: '
+
+        if error is None:
+            got_attributes = False
+            got_telemetry = False
+
+            if data.get("attributes") is not None:
+                for entry in data.get("attributes"):
+                    if entry.get("ts") is not None and len(entry.get("values")) > 0:
+                        got_attributes = True
+                        break
+
+            if data.get("telemetry") is not None:
+                for entry in data.get("telemetry"):
+                    if entry.get("ts") is not None and len(entry.get("values")) > 0:
+                        got_telemetry = True
+                        break
+
+            if got_attributes == False and got_telemetry == False:
+                error = 'No telemetry and attributes in data: '
+
         if error is not None:
             json_data = dumps(data)
             if isinstance(json_data, bytes):

--- a/thingsboard_gateway/tb_utility/tb_utility.py
+++ b/thingsboard_gateway/tb_utility/tb_utility.py
@@ -48,11 +48,8 @@ class TBUtility:
             got_attributes = False
             got_telemetry = False
 
-            if data.get("attributes") is not None:
-                for entry in data.get("attributes"):
-                    if entry.get("ts") is not None and len(entry.get("values")) > 0:
-                        got_attributes = True
-                        break
+            if data.get("attributes") is not None and len(data.get("attributes")) > 0:
+                got_attributes = True
 
             if data.get("telemetry") is not None:
                 for entry in data.get("telemetry"):

--- a/thingsboard_gateway/tb_utility/tb_utility.py
+++ b/thingsboard_gateway/tb_utility/tb_utility.py
@@ -60,7 +60,7 @@ class TBUtility:
                         got_telemetry = True
                         break
 
-            if got_attributes == False and got_telemetry == False:
+            if got_attributes is False and got_telemetry is False:
                 error = 'No telemetry and attributes in data: '
 
         if error is not None:


### PR DESCRIPTION
Recently changed data validation function does its checks by treating
attributes/values as they were dictionaries; however, they are lists
of dictionaries.

data["telemetry"].get("ts") is bound to fail: the correct check would be
data["telemetry"][i].get("ts"), for each element i.

Signed-off-by: Simone Libutti <simone.libutti@ibtsystems.it>