### PR TITLE
Source distribution fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft thingsboard_gateway/config
+include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft thingsboard_gateway/config

--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,4 @@ setup(
     entry_points={
         'console_scripts': [
             'thingsboard-gateway = thingsboard_gateway.tb_gateway:daemon'
-        ]},
-    package_data={
-        "*": ["config/*"]
-    })
-
-
-
+        ]})


### PR DESCRIPTION
These changes ensure that the example config files and the license text are included in the source distribution uploaded to pypi. They were tested by running `python3 setup.py sdist` and examining the generated tarball.

I recommend making a minor release if these changes are accepted so that the new files show up in a release on pypi.