### PR TITLE
Improvements to systemd service file

### DIFF
--- a/for_build/etc/systemd/system/thingsboard-gateway.service
+++ b/for_build/etc/systemd/system/thingsboard-gateway.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=ThingsBoard Gateway
 After=multi-user.target
+ConditionPathExists=/etc/thingsboard-gateway/config/tb_gateway.yaml
 
 [Service]
 Type=simple
 User=thingsboard_gateway
 Group=thingsboard_gateway
 
+WorkingDirectory=/var/lib/thingsboard_gateway
 ExecStart=/usr/bin/python3 -c "from thingsboard_gateway.tb_gateway import daemon; daemon()"
 ExecStop=/bin/kill -INT $MAINPID
 ExecReload=/bin/kill -TERM $MAINPID


### PR DESCRIPTION
* Only start the service if the config exists. This avoids wasting time in an infinite restart loop if thingsboard-gateway is unconfigured.

* Start the service in the thingsboard_gateway home directory.