### PR TITLE
remove redundant tls_insecure_set() call

### DIFF
--- a/thingsboard_gateway/gateway/tb_client.py
+++ b/thingsboard_gateway/gateway/tb_client.py
@@ -54,11 +54,8 @@ class TBClient(threading.Thread):
                                         tls_version=PROTOCOL_TLSv1_2,
                                         cert_reqs=CERT_REQUIRED,
                                         ciphers=None)
-            if (self.__ca_cert is not None and (self.__private_key is not None or self.__cert is not None)):
-                self.client._client.tls_insecure_set(False)
             if credentials.get("insecure", False):
                 self.client._client.tls_insecure_set(True)
-        # if self.__tls and self.__ca_cert is None and self.__private_key is None and self.__cert is None:
         # pylint: disable=protected-access
         # Adding callbacks
         self.client._client._on_connect = self._on_connect


### PR DESCRIPTION
When `tls_set()` options include `cert_reqs=ssl.CERT_REQUIRED` then the verification of a server certificate is already implicit, the removed call (`tls_insecure_set(True)`) was redundant, as was the previous commented out line.