### PR TITLE
Fix connector types

### DIFF
--- a/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
+++ b/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
@@ -36,7 +36,7 @@ from thingsboard_gateway.connectors.bacnet.bacnet_utilities.tb_gateway_bacnet_ap
 
 class BACnetConnector(Thread, Connector):
     def __init__(self, gateway, config, connector_type):
-        self.__connector_type = connector_type
+        self._connector_type = connector_type
         self.statistics = {'MessagesReceived': 0,
                            'MessagesSent': 0}
         super().__init__()
@@ -52,8 +52,8 @@ class BACnetConnector(Thread, Connector):
         self.__stopped = False
         self.__config_devices = self.__config["devices"]
         self.default_converters = {
-            "uplink_converter": TBModuleLoader.import_module(self.__connector_type, "BACnetUplinkConverter"),
-            "downlink_converter": TBModuleLoader.import_module(self.__connector_type, "BACnetDownlinkConverter")}
+            "uplink_converter": TBModuleLoader.import_module(self._connector_type, "BACnetUplinkConverter"),
+            "downlink_converter": TBModuleLoader.import_module(self._connector_type, "BACnetDownlinkConverter")}
         self.__request_functions = {"writeProperty": self._application.do_write_property,
                                     "readProperty": self._application.do_read_property,
                                     "risingEdge": self._application.do_binary_rising_edge}
@@ -244,7 +244,7 @@ class BACnetConnector(Thread, Connector):
                 try:
                     for converter_type in self.default_converters:
                         converter_object = self.default_converters[converter_type] if datatype_config.get(
-                            "class") is None else TBModuleLoader.import_module(self.__connector_type,
+                            "class") is None else TBModuleLoader.import_module(self._connector_type,
                                                                                device.get("class"))
                         datatype_config[converter_type] = converter_object(device)
                 except Exception as e:

--- a/thingsboard_gateway/connectors/ble/ble_connector.py
+++ b/thingsboard_gateway/connectors/ble/ble_connector.py
@@ -29,7 +29,7 @@ from thingsboard_gateway.tb_utility.tb_loader import TBModuleLoader
 class BLEConnector(Connector, Thread):
     def __init__(self, gateway, config, connector_type):
         super().__init__()
-        self.__connector_type = connector_type
+        self._connector_type = connector_type
         self.__default_services = list(range(0x1800, 0x183A))
         self.statistics = {'MessagesReceived': 0,
                            'MessagesSent': 0}
@@ -423,7 +423,7 @@ class BLEConnector(Connector, Thread):
                             converter = None
                             if type_section.get('converter') is not None:
                                 try:
-                                    module = TBModuleLoader.import_module(self.__connector_type,
+                                    module = TBModuleLoader.import_module(self._connector_type,
                                                                           type_section['converter'])
                                     if module is not None:
                                         log.debug('Custom converter for device %s - found!',

--- a/thingsboard_gateway/connectors/can/can_connector.py
+++ b/thingsboard_gateway/connectors/can/can_connector.py
@@ -69,7 +69,7 @@ class CanConnector(Connector, Thread):
         super().__init__()
         self.setName(config.get("name", 'CAN Connector ' + ''.join(choice(ascii_lowercase) for _ in range(5))))
         self.__gateway = gateway
-        self.__connector_type = connector_type
+        self._connector_type = connector_type
         self.__bus_conf = {}
         self.__bus = None
         self.__reconnect_count = 0
@@ -372,7 +372,7 @@ class CanConnector(Connector, Thread):
         for device_config in config.get("devices"):
             is_device_config_valid = False
             device_name = device_config["name"]
-            device_type = device_config.get("type", self.__connector_type)
+            device_type = device_config.get("type", self._connector_type)
             strict_eval = device_config.get("strictEval", self.DEFAULT_STRICT_EVAL_FLAG)
 
             self.__devices[device_name] = {}
@@ -580,11 +580,11 @@ class CanConnector(Connector, Thread):
             if need_uplink:
                 uplink = config.get("uplink")
                 return BytesCanUplinkConverter() if uplink is None \
-                    else TBModuleLoader.import_module(self.__connector_type, uplink)
+                    else TBModuleLoader.import_module(self._connector_type, uplink)
             else:
                 downlink = config.get("downlink")
                 return BytesCanDownlinkConverter() if downlink is None \
-                    else TBModuleLoader.import_module(self.__connector_type, downlink)
+                    else TBModuleLoader.import_module(self._connector_type, downlink)
 
 
 class Poller(Thread):

--- a/thingsboard_gateway/connectors/ftp/ftp_connector.py
+++ b/thingsboard_gateway/connectors/ftp/ftp_connector.py
@@ -45,7 +45,7 @@ class FTPConnector(Connector, Thread):
                            'MessagesSent': 0}
         self.__log = log
         self.__config = config
-        self.__connector_type = connector_type
+        self._connector_type = connector_type
         self.__gateway = gateway
         self.security = {**self.__config['security']} if self.__config['security']['type'] == 'basic' else {
             'username': 'anonymous', "password": 'anonymous@'}

--- a/thingsboard_gateway/connectors/odbc/odbc_connector.py
+++ b/thingsboard_gateway/connectors/odbc/odbc_connector.py
@@ -55,7 +55,7 @@ class OdbcConnector(Connector, Thread):
         self.statistics = {'MessagesReceived': 0,
                            'MessagesSent': 0}
         self.__gateway = gateway
-        self.__connector_type = connector_type
+        self._connector_type = connector_type
         self.__config = config
         self.__stopped = False
 
@@ -74,7 +74,7 @@ class OdbcConnector(Connector, Thread):
         self.__timeseries_columns = []
 
         self.__converter = OdbcUplinkConverter() if not self.__config.get("converter", "") else \
-            TBModuleLoader.import_module(self.__connector_type, self.__config["converter"])
+            TBModuleLoader.import_module(self._connector_type, self.__config["converter"])
 
         self.__configure_pyodbc()
         self.__parse_rpc_config()
@@ -252,7 +252,7 @@ class OdbcConnector(Connector, Thread):
 
             self.__iterator["value"] = getattr(row, self.__iterator["name"])
             self.__check_and_send(device_name,
-                                  self.__config["mapping"]["device"].get("type", self.__connector_type),
+                                  self.__config["mapping"]["device"].get("type", self._connector_type),
                                   to_send)
         except Exception as e:
             log.warning("[%s] Failed to process database row: %s", self.get_name(), str(e))

--- a/thingsboard_gateway/connectors/request/request_connector.py
+++ b/thingsboard_gateway/connectors/request/request_connector.py
@@ -48,7 +48,7 @@ class RequestConnector(Connector, Thread):
                            'MessagesSent': 0}
         self.__rpc_requests = []
         self.__config = config
-        self.__connector_type = connector_type
+        self._connector_type = connector_type
         self.__gateway = gateway
         self.__security = HTTPBasicAuth(self.__config["security"]["username"], self.__config["security"]["password"]) if \
             self.__config["security"]["type"] == "basic" else None
@@ -142,7 +142,7 @@ class RequestConnector(Connector, Thread):
                 log.debug(endpoint)
                 converter = None
                 if endpoint["converter"]["type"] == "custom":
-                    module = TBModuleLoader.import_module(self.__connector_type, endpoint["converter"]["extension"])
+                    module = TBModuleLoader.import_module(self._connector_type, endpoint["converter"]["extension"])
                     if module is not None:
                         log.debug('Custom converter for url %s - found!', endpoint["url"])
                         converter = module(endpoint)


### PR DESCRIPTION
@zbeacon Updated the fix for the connector type issue discussed in #548.  Still not sure whether the other change is desired or not so I decided to create a new PR that does not include it.

Here is the description of the connector type issue again:

Within _rpc_request_handler in the TBGatewayService, a connector's type is compared to the module initially attached to a method to determine whether to forward the content to the server side rpc handler.  Without the correct property "_connector_type" specified on a connector, you will receive an error saying "[Connector Class] object has no attribute _connector_type."  Below is the relevant code from the _rpc_request_handler.

<img width="671" alt="tb_gateway_service" src="https://user-images.githubusercontent.com/46691358/128592988-1c31aac0-c6a3-435a-aec0-a5885ea09886.png">