### PR TITLE
typo error

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -998,7 +998,7 @@ class TBGatewayService:
                         device_data_to_save = {
                             "connector": self.available_connectors[devices[device_name][0]],
                             "device_type": devices[device_name][1]}
-                        if len(devices[device_name] > 2) and device_name not in self.__renamed_devices:
+                        if len(devices[device_name]) > 2 and device_name not in self.__renamed_devices:
                             new_device_name = devices[device_name][2]
                             self.__renamed_devices[device_name] = new_device_name
                         self.__connected_devices[device_name] = device_data_to_save


### PR DESCRIPTION
''2022-01-05 00:12:55' - ERROR - tb_gateway_service - 1007 - '>' not supported between instances of 'list' and 'int''
Traceback (most recent call last):
  File "/Users/ysimonx/Developpement/tb-gateway/env/lib/python3.9/site-packages/thingsboard_gateway/gateway/tb_gateway_service.py", line 1001, in __load_persistent_devices
    if len(devices[device_name] > 2) and device_name not in self.__renamed_devices:
TypeError: '>' not supported between instances of 'list' and 'int'

) seems to be at a wrong place