### PR TITLE
Update for performance improvement when mapping OPCUA nodes

### DIFF
--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -507,6 +507,7 @@ class OpcUaConnector(Thread, Connector):
                 log.error("Device node not found with expression: %s", TBUtility.get_value(device["deviceNodePattern"], get_tag=True))
         return result
 
+    @cachetools.func.ttl_cache(maxsize=1000, ttl=10 * 60)
     def get_node_path(self, node: Node):
         return '\\.'.join(node.get_browse_name().Name for node in node.get_path(200000))
 


### PR DESCRIPTION
based on https://github.com/thingsboard/thingsboard-gateway/issues/698
when I start tb-gateway, with only 15 mapping elements on a remote opcua server, it takes 3 minutes before being ready
the get_node_path is done several times, is slow, is called many times for the same node : let's cache it

with this improvement, on my computer, instead of 3 minutes, the tb gateway is ready in 30 secondes