### PR TITLE
OPCUA: Use SourceTimestamp

### DIFF
--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -627,7 +627,7 @@ class SubHandler(object):
         try:
             log.debug("Python: New data change event on node %s, with val: %s and data %s", node, val, str(data))
             subscription = self.connector.subscribed[node]
-            converted_data = subscription["converter"].convert((subscription["config_path"], subscription["path"]), val)
+            converted_data = subscription["converter"].convert((subscription["config_path"], subscription["path"]), val, data)
             self.connector.statistics['MessagesReceived'] = self.connector.statistics['MessagesReceived'] + 1
             self.connector.data_to_send.append(converted_data)
             self.connector.statistics['MessagesSent'] = self.connector.statistics['MessagesSent'] + 1

--- a/thingsboard_gateway/connectors/opcua/opcua_converter.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_converter.py
@@ -17,5 +17,5 @@ from thingsboard_gateway.connectors.converter import Converter, abstractmethod, 
 
 class OpcUaConverter(Converter):
     @abstractmethod
-    def convert(self, config, data):
+    def convert(self, config, val, data = None):
         pass

--- a/thingsboard_gateway/connectors/opcua/opcua_uplink_converter.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_uplink_converter.py
@@ -13,6 +13,8 @@
 #     limitations under the License.
 
 from re import fullmatch
+from time import time
+from datetime import timezone
 
 from thingsboard_gateway.connectors.opcua.opcua_converter import OpcUaConverter, log
 from thingsboard_gateway.tb_utility.tb_utility import TBUtility
@@ -22,7 +24,7 @@ class OpcUaUplinkConverter(OpcUaConverter):
     def __init__(self, config):
         self.__config = config
 
-    def convert(self, config, data):
+    def convert(self, config, val, data = None):
         device_name = self.__config["deviceName"]
         result = {"deviceName": device_name,
                   "deviceType": self.__config.get("deviceType", "OPC-UA Device"),
@@ -41,7 +43,19 @@ class OpcUaUplinkConverter(OpcUaConverter):
                     else:
                         config_information = config.replace('\\\\', '\\')
                     if path == config_information or fullmatch(path, config_information) or path.replace('\\\\', '\\') == config_information:
-                        result[information_types[information_type]].append({information["key"]: information["path"].replace("${" + path + "}", str(data))})
+                        full_key = information["key"]
+                        full_value = information["path"].replace("${"+path+"}", str(val))
+                        if information_type == 'timeseries' and data is not None:
+                            # Note: SourceTimestamp and ServerTimestamp may be naive datetime objects, hence for the timestamp() the tz must first be overwritten to UTC (which it is according to the spec)
+                            if data.monitored_item.Value.SourceTimestamp is not None:
+                                timestamp = int(data.monitored_item.Value.SourceTimestamp.replace(tzinfo=timezone.utc).timestamp()*1000)
+                            elif data.monitored_item.Value.ServerTimestamp is not None:
+                                timestamp = int(data.monitored_item.Value.ServerTimestamp.replace(tzinfo=timezone.utc).timestamp()*1000)
+                            else:
+                                timestamp = int(time()*1000)
+                            result[information_types[information_type]].append({"ts": timestamp, 'values': {full_key: full_value}})
+                        else:
+                            result[information_types[information_type]].append({full_key: full_value})
             return result
         except Exception as e:
             log.exception(e)


### PR DESCRIPTION
In the OPC-UA protocol a source timestamp is available to record/reflect when a variable was sampled by the server, see SourceTimestamp in https://reference.opcfoundation.org/v104/Core/docs/Part4/7.7.3/. This timestamp should be used for recording the data in thingsboard, because:

The SourceTimestamp accurately reflects when the value was created. Any data transfer or processing time delays will not affect the measument.
Multiple synchronized value updates (e.g. in case of a complex control loop) will be recorded with the same timestamp in thingsboard.

Closes https://github.com/thingsboard/thingsboard-gateway/issues/702