### PR TITLE
opc ua : mapping telemetry and/or attributes fails

### DIFF
--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -596,9 +596,9 @@ class OpcUaConnector(Thread, Connector):
                                 if self.__show_map:
                                     log.debug("SHOW MAP: Search in %s", new_node_path)
                                 self.__search_node(child_node, fullpath, result=result)
-                            elif new_node_class == ua.NodeClass.Variable:
-                                log.debug("Found in %s", new_node_path)
-                                result.append(child_node)
+                            # elif new_node_class == ua.NodeClass.Variable:
+                            #     log.debug("Found in %s", new_node_path)
+                            #     result.append(child_node)
                             elif new_node_class == ua.NodeClass.Method and search_method:
                                 log.debug("Found in %s", new_node_path)
                                 result.append(child_node)


### PR DESCRIPTION
cf https://github.com/thingsboard/thingsboard-gateway/issues/735

in my opcua.json, i have a key for both telemetry and attributes
${User Registers\.cPURE\.Fan\.DeltaP_100}

but, opc ua connector matches this key with both

User Registers.cPURE.Fan.DeltaP_10
and
User Registers.cPURE.Fan.DeltaP_100

we should not select this node (DeltaP_10 !!), 
this node is selected because the "scanning" process selects node of type variable, even when a partial match is done.
