### PR TITLE
Fixed Node module import for opcua library

### DIFF
--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     print("OPC-UA library not found")
     TBUtility.install_package("opcua")
-    from opcua import Client, ua
+    from opcua import Client, Node, ua
 
 try:   
     from opcua.crypto import uacrypto


### PR DESCRIPTION
Currently, the except block didn't import the Node module from the opcua library, thus leading to possible errors when referred (e.g., line 551).