### PR TITLE
Added 'Remote Response' functionality for REST Connector

### DIFF
--- a/thingsboard_gateway/connectors/rest/rest_connector.py
+++ b/thingsboard_gateway/connectors/rest/rest_connector.py
@@ -17,7 +17,7 @@ from random import choice
 from re import fullmatch
 from string import ascii_lowercase
 from threading import Thread
-from time import time
+from time import time, sleep
 import ssl
 import os
 
@@ -175,6 +175,13 @@ class RESTConnector(Connector, Thread):
                         response = response_queue.get_nowait()
                         log.debug(response)
                     del response_queue
+
+            # ONLY if initialized "response" section for endpoint
+            # check if attribute update relates to some responseAttribute
+            for endpoint in self.__config['mapping']:
+                response_attribute = endpoint.get('response', {}).get('responseAttribute')
+                if list(content['data'].keys())[0] == response_attribute:
+                    BaseDataHandler.responses_queue.put(content['data'][response_attribute])
         except Exception as e:
             log.exception(e)
 
@@ -304,10 +311,16 @@ class RESTConnector(Connector, Thread):
 
 
 class BaseDataHandler:
+    responses_queue = Queue()
+
     def __init__(self, send_to_storage, name, endpoint):
         self.send_to_storage = send_to_storage
         self.__name = name
         self.__endpoint = endpoint
+
+        self.success_response = self.__endpoint['config'].get('response', {}).get('successResponse')
+        self.unsuccessful_response = self.__endpoint['config'].get('response', {}).get('unsuccessfulResponse')
+        self.response_expected = self.__endpoint['config'].get('response', {}).get('responseExpected', False)
 
     @property
     def name(self):
@@ -335,27 +348,54 @@ class BaseDataHandler:
 
             return json_data
 
+    @staticmethod
+    def modify_data_for_remote_response(data, modify):
+        if modify:
+            data['attributes'].append({'responseExpected': True})
+
+    def get_response(self):
+        if self.response_expected:
+            if self.success_response:
+                return web.Response(body=str(self.success_response) if self.success_response else None, status=200)
+            else:
+                time_point = time()
+                while not time() - time_point >= self.endpoint['config'].get('response', {}).get('timeout', 120):
+                    if not BaseDataHandler.responses_queue.empty():
+                        response = BaseDataHandler.responses_queue.get()
+                        return web.Response(body=str(response), status=200)
+
+                    sleep(.2)
+
+                return web.Response(body=str(self.unsuccessful_response) if self.unsuccessful_response else None,
+                                    status=408)
+
 
 class AnonymousDataHandler(BaseDataHandler):
     async def __call__(self, request: web.Request):
         json_data = await self._convert_data_from_request(request)
 
         if not json_data and not len(request.query):
-            return web.Response(status=415)
+            return web.Response(body=str(self.unsuccessful_response) if self.unsuccessful_response else None, status=415)
+
         endpoint_config = self.endpoint['config']
         if request.method.upper() not in [method.upper() for method in endpoint_config['HTTPMethods']]:
-            return web.Response(status=405)
+            return web.Response(body=str(self.unsuccessful_response) if self.unsuccessful_response else None, status=405)
+
         try:
             log.info("CONVERTER CONFIG: %r", endpoint_config['converter'])
             converter = self.endpoint['converter'](endpoint_config['converter'])
             data = json_data if json_data else dict(request.query)
             converted_data = converter.convert(config=endpoint_config['converter'], data=data)
+
+            self.modify_data_for_remote_response(converted_data, self.response_expected)
+
             self.send_to_storage(self.name, converted_data)
             log.info("CONVERTED_DATA: %r", converted_data)
-            return web.Response(status=200)
+
+            return self.get_response()
         except Exception as e:
             log.exception("Error while post to anonymous handler: %s", e)
-            return web.Response(status=500)
+            return web.Response(body=str(self.success_response) if self.success_response else None, status=500)
 
 
 class BasicDataHandler(BaseDataHandler):
@@ -368,23 +408,31 @@ class BasicDataHandler(BaseDataHandler):
         auth = BasicAuth.decode(request.headers.get('Authorization'))
         if self.verify(auth.login, auth.password):
             json_data = await self._convert_data_from_request(request)
+
             if not json_data:
-                return web.Response(status=415)
+                return web.Response(body=self.unsuccessful_response, status=415)
+
             endpoint_config = self.endpoint['config']
+
             if request.method.upper() not in [method.upper() for method in endpoint_config['HTTPMethods']]:
-                return web.Response(status=405)
+                return web.Response(body=self.unsuccessful_response, status=405)
+
             try:
                 log.info("CONVERTER CONFIG: %r", endpoint_config['converter'])
                 converter = self.endpoint['converter'](endpoint_config['converter'])
                 converted_data = converter.convert(config=endpoint_config['converter'], data=json_data)
+
+                self.modify_data_for_remote_response(converted_data, self.response_expected)
+
                 self.send_to_storage(self.name, converted_data)
                 log.info("CONVERTED_DATA: %r", converted_data)
-                return web.Response(status=200)
+
+                return self.get_response()
             except Exception as e:
                 log.exception("Error while post to basic handler: %s", e)
-                return web.Response(status=500)
+                return web.Response(body=self.unsuccessful_response, status=500)
 
-        return web.Response(status=401)
+        return web.Response(body=self.unsuccessful_response, status=401)
 
 
 class Users:


### PR DESCRIPTION
Response in REST Connector can have 3 variants of configuration now:

1. default response (without extra configuration, return only HTTP Status Code);
2. hardcoded response body, for this option you have to specify a new section and 2 new optional parameters as in the example below:
    <img width="281" alt="зображення" src="https://user-images.githubusercontent.com/43861229/159018179-bf66d0ff-18b8-428a-9abd-50e216e20bff.png">
3. (ADVANCED) remote response that will return by ThingsBoard. 
    1. To configure that variant you have to specify a new section in the config file as in the example below:
        <img width="264" alt="зображення" src="https://user-images.githubusercontent.com/43861229/159018690-024ca07d-daba-42a2-8bf9-1da8518764f1.png">
    2. Configure RuleChain in ThingsBoard:
        <img width="851" alt="зображення" src="https://user-images.githubusercontent.com/43861229/159019027-7d1844d0-ea03-4686-9938-6f358c8a8348.png">
        1. Yellow Rule Node. 
            <img width="361" alt="зображення" src="https://user-images.githubusercontent.com/43861229/159019362-4ded7e6f-8444-4186-9aa3-422befd1f849.png">
        2. Blue Rule Node
           <img width="834" alt="зображення" src="https://user-images.githubusercontent.com/43861229/159019501-9dbae29a-e475-4755-8e69-2515baf0b6fd.png">
 
