### PR TITLE
Update IoT Gateway Connector Configuration

### DIFF
--- a/for_build/etc/thingsboard-gateway/config/custom_serial.json
+++ b/for_build/etc/thingsboard-gateway/config/custom_serial.json
@@ -1,11 +1,11 @@
 {
   "name": "Custom serial connector",
+  "port": "/dev/ttyUSB0",
+  "baudrate": 9600,
   "devices": [
     {
       "name": "CustomSerialDevice1",
       "type": "default",
-      "port": "/dev/ttyUSB0",
-      "baudrate": 9600,
       "converter": "CustomSerialUplinkConverter",
       "telemetry": [
         {

--- a/for_build/etc/thingsboard-gateway/config/mqtt.json
+++ b/for_build/etc/thingsboard-gateway/config/mqtt.json
@@ -116,8 +116,8 @@
     {
       "retain": false,
       "topicFilter": "v1/devices/me/attributes/request",
-      "deviceNameTopicExpression": "${SerialNumber}",
-      "attributeNameJsonExpression": "${sensorModel}"
+      "topicExpression": "${SerialNumber}",
+      "valueExpression": "${sensorModel}"
     }
   ],
   "attributeUpdates": [

--- a/thingsboard_gateway/config/custom_serial.json
+++ b/thingsboard_gateway/config/custom_serial.json
@@ -1,11 +1,11 @@
 {
   "name": "Custom serial connector",
+  "port": "/dev/ttyUSB0",
+  "baudrate": 9600,
   "devices": [
     {
       "name": "CustomSerialDevice1",
       "type": "default",
-      "port": "/dev/ttyUSB0",
-      "baudrate": 9600,
       "converter": "CustomSerialUplinkConverter",
       "telemetry": [
         {

--- a/thingsboard_gateway/config/mqtt.json
+++ b/thingsboard_gateway/config/mqtt.json
@@ -116,8 +116,8 @@
     {
       "retain": false,
       "topicFilter": "v1/devices/me/attributes/request",
-      "deviceNameTopicExpression": "${SerialNumber}",
-      "attributeNameJsonExpression": "${sensorModel}"
+      "topicExpression": "${SerialNumber}",
+      "valueExpression": "${sensorModel}"
     }
   ],
   "attributeUpdates": [


### PR DESCRIPTION
Hi, I am very interested in this repository.
1. When learning Custom IoT Gateway Connector, on line 58 of `custom_serial_connector.py`, debug `self.__config.get('port', '/dev/ttyUSB0')`, could not get custom port.
So decided to update `custom_serial.json`.

2. Fix errors on startup when using MQTT Connector.
```
""2022-03-26 10:04:47" - |ERROR| - [mqtt_connector.py] - mqtt_connector - load_handlers - 138 - Mandatory key 'topicExpression' missing from attributeRequests handler: {"retain": false, "topicFilter": "v1/devices/me/attributes/request", "deviceNameTopicExpression": "${SerialNumber}", "attributeNameJsonExpression": "${sensorModel}"}"
""2022-03-26 10:04:47" - |ERROR| - [mqtt_connector.py] - mqtt_connector - load_handlers - 138 - Mandatory key 'valueExpression' missing from attributeRequests handler: {"retain": false, "topicFilter": "v1/devices/me/attributes/request", "deviceNameTopicExpression": "${SerialNumber}", "attributeNameJsonExpression": "${sensorModel}"}"
""2022-03-26 10:04:47" - |ERROR| - [mqtt_connector.py] - mqtt_connector - load_handlers - 145 - attributeRequests handler is missing some mandatory keys => rejected: {"retain": false, "topicFilter": "v1/devices/me/attributes/request", "deviceNameTopicExpression": "${SerialNumber}", "attributeNameJsonExpression": "${sensorModel}"}"
```