### PR TITLE
Fix ignoring more than one command configurations.

### DIFF
--- a/tests/data/can/ts_and_attr.json
+++ b/tests/data/can/ts_and_attr.json
@@ -42,6 +42,42 @@
           "value": "4:2:int"
         }
       ]
+    },
+    {
+      "name": "Car3",
+      "sendDataOnlyOnChange": true,
+      "timeseries": [
+        {
+          "key": "param1",
+          "nodeId": 3,
+          "command": "0:2:little:11111",
+          "value": "2:2:int"
+        },
+        {
+          "key": "param2",
+          "nodeId": 3,
+          "command": "0:2:little:22222",
+          "value": "2:2:int"
+        }
+      ]
+    },
+    {
+      "name": "Car4",
+      "sendDataOnlyOnChange": true,
+      "timeseries": [
+        {
+          "key": "firstCommandConfig",
+          "nodeId": 4,
+          "command": "0:2:little:11111",
+          "value": "2:2:int"
+        },
+        {
+          "key": "ignoredAnotherCommandConfig",
+          "nodeId": 4,
+          "command": "3:3:little:22222",
+          "value": "2:2:int"
+        }
+      ]
     }
   ]
 }

--- a/thingsboard_gateway/connectors/can/can_connector.py
+++ b/thingsboard_gateway/connectors/can/can_connector.py
@@ -439,7 +439,7 @@ class CanConnector(Connector, Thread):
                                     self.get_name(), tb_key, config_key, )
                         continue
 
-                    if msg_config.get("command", ""):
+                    if msg_config.get("command"):
                         cmd_config = self.__parse_command_config(msg_config["command"])
                         if cmd_config is None:
                             log.warning("[%s] Ignore '%s' %s configuration: wrong command configuration",
@@ -451,8 +451,14 @@ class CanConnector(Connector, Thread):
                         if node_id not in self.__commands:
                             self.__commands[node_id] = cmd_config
                         else:
-                            # TODO: warn user if previous cmd_config differs from current cmd_config
-                            pass
+                            prev_cmd_config = self.__commands[node_id]
+                            if cmd_config["start"] != prev_cmd_config["start"] or \
+                                    cmd_config["length"] != prev_cmd_config["length"] or \
+                                    cmd_config["byteorder"] != prev_cmd_config["byteorder"]:
+                                log.warning("[%s] Ignore '%s' %s configuration: "
+                                            "another command configuration already added for arbitration_id %d",
+                                            self.get_name(), tb_key, config_key, node_id)
+                                continue
                     else:
                         cmd_id = self.NO_CMD_ID
                         self.__commands[node_id] = None

--- a/thingsboard_gateway/connectors/can/can_connector.py
+++ b/thingsboard_gateway/connectors/can/can_connector.py
@@ -439,7 +439,7 @@ class CanConnector(Connector, Thread):
                                     self.get_name(), tb_key, config_key, )
                         continue
 
-                    if msg_config.get("command", "") and node_id not in self.__commands:
+                    if msg_config.get("command", ""):
                         cmd_config = self.__parse_command_config(msg_config["command"])
                         if cmd_config is None:
                             log.warning("[%s] Ignore '%s' %s configuration: wrong command configuration",
@@ -447,7 +447,12 @@ class CanConnector(Connector, Thread):
                             continue
 
                         cmd_id = cmd_config["value"]
-                        self.__commands[node_id] = cmd_config
+
+                        if node_id not in self.__commands:
+                            self.__commands[node_id] = cmd_config
+                        else:
+                            # TODO: warn user if previous cmd_config differs from current cmd_config
+                            pass
                     else:
                         cmd_id = self.NO_CMD_ID
                         self.__commands[node_id] = None


### PR DESCRIPTION
Without this PR multiple command configuration (see example below) for the same nodeId doesn't work at all:
```
            "timeseries":
            [ {
                    "key": "INVCH_Bdc_bExporting",
                    "nodeId": 419419328,
                    "isExtendedId": true,
                    "command": "0:1:little:0",
                    "value": "2:1:int",
                    "expression": "value"
                }, {
                    "key": "18FFD4C0_Index3_Byte1",
                    "nodeId": 419419328,
                    "isExtendedId": true,
                    "command": "0:1:little:3",
                    "value": "1:1:int",
                    "expression": "value"
                }
            ]
        }
```