### PR TITLE
Serial connector: Load device config from device array 

### DIFF
--- a/thingsboard_gateway/extensions/serial/custom_serial_connector.py
+++ b/thingsboard_gateway/extensions/serial/custom_serial_connector.py
@@ -18,8 +18,14 @@ import time
 from random import choice
 from string import ascii_lowercase
 from threading import Thread
+from thingsboard_gateway.tb_utility.tb_utility import TBUtility
 
-import serial
+try:
+    import serial
+except ImportError:
+    print("pyserial library not found - installing...")
+    TBUtility.install_package("pyserial")
+    import serial
 
 from thingsboard_gateway.connectors.connector import Connector, log  # Import base class for connector and logger
 from thingsboard_gateway.tb_utility.tb_loader import TBModuleLoader

--- a/thingsboard_gateway/extensions/serial/custom_serial_connector.py
+++ b/thingsboard_gateway/extensions/serial/custom_serial_connector.py
@@ -55,24 +55,25 @@ class CustomSerialConnector(Thread, Connector):  # Define a connector class, it 
                     self.__devices[device]["serial"] = None
                     while self.__devices[device]["serial"] is None or not self.__devices[device]["serial"].isOpen():  # Try connect
                         # connection to serial port with parameters from configuration file or default
-                        self.__devices[device]["serial"] = serial.Serial(port=self.__config.get('port', '/dev/ttyUSB0'),
-                                                                         baudrate=self.__config.get('baudrate', 9600),
-                                                                         bytesize=self.__config.get('bytesize', serial.EIGHTBITS),
-                                                                         parity=self.__config.get('parity', serial.PARITY_NONE),
-                                                                         stopbits=self.__config.get('stopbits', serial.STOPBITS_ONE),
-                                                                         timeout=self.__config.get('timeout', 1),
-                                                                         xonxoff=self.__config.get('xonxoff', False),
-                                                                         rtscts=self.__config.get('rtscts', False),
-                                                                         write_timeout=self.__config.get('write_timeout', None),
-                                                                         dsrdtr=self.__config.get('dsrdtr', False),
-                                                                         inter_byte_timeout=self.__config.get('inter_byte_timeout', None),
-                                                                         exclusive=self.__config.get('exclusive', None))
+                        device_config = self.__devices[device]["device_config"]
+                        self.__devices[device]["serial"] = serial.Serial(port=device_config.get('port', '/dev/ttyUSB0'),
+                                                                         baudrate=device_config.get('baudrate', 9600),
+                                                                         bytesize=device_config.get('bytesize', serial.EIGHTBITS),
+                                                                         parity=device_config.get('parity', serial.PARITY_NONE),
+                                                                         stopbits=device_config.get('stopbits', serial.STOPBITS_ONE),
+                                                                         timeout=device_config.get('timeout', 1),
+                                                                         xonxoff=device_config.get('xonxoff', False),
+                                                                         rtscts=device_config.get('rtscts', False),
+                                                                         write_timeout=device_config.get('write_timeout', None),
+                                                                         dsrdtr=device_config.get('dsrdtr', False),
+                                                                         inter_byte_timeout=device_config.get('inter_byte_timeout', None),
+                                                                         exclusive=device_config.get('exclusive', None))
                         time.sleep(.1)
                         if time.time() - connection_start > 10:  # Break connection try if it setting up for 10 seconds
-                            log.error("Connection refused per timeout for device %s", self.__devices[device]["device_config"].get("name"))
+                            log.error("Connection refused per timeout for device %s", device_config.get("name"))
                             break
             except serial.serialutil.SerialException:
-                log.error("Port %s for device %s - not found", self.__config.get('port', '/dev/ttyUSB0'), device)
+                log.error("Port %s for device %s - not found", self.__devices[device]["device_config"].get('port', '/dev/ttyUSB0'), device)
             except Exception as e:
                 log.exception(e)
             else:  # if no exception handled - add device and change connection state


### PR DESCRIPTION
**Description:** 

The PR resolves three issues: 
- [x] The current implementation for custom serial connector looks for the device configuration at the root of the configuration json. As per the [documentation](https://thingsboard.io/docs/iot-gateway/custom/#step-1-define-serialconnector-configuration) and to support configurability at the device level, the configuration should be fetched from each device array item. 
- [x] The thingsboard gateway's **_del_device_** method expects the device name as an input. The current implementation wrongly passes the device object instead.  
- [x] Install pyserial library is not installed 
 