### PR TITLE
Fix devices list management after a delete_device RPC from thingsboard

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -377,7 +377,10 @@ class TBGatewayService:
             log.debug("Current renamed_devices dict: %s", self.__renamed_devices)
         if deleted_device_name in self.__connected_devices:
             del self.__connected_devices[deleted_device_name]
-            log.debug("Device %s - was removed", deleted_device_name)
+            log.debug("Device %s - was removed from __connected_devices", deleted_device_name)
+        if deleted_device_name in self.__saved_devices:
+            del self.__saved_devices[deleted_device_name]
+            log.debug("Device %s - was removed from __saved_devices", deleted_device_name)
         self.__save_persistent_devices()
         self.__load_persistent_devices()
 


### PR DESCRIPTION
When Thingsboard sends a gateway_device_deleted RPC to the gateway, the device is removed from persistent devices file and from local __connected_devices array.
The device is still present in local __saved_devices array, so if I recreate a device with the same name, the first time it sends a message to Thingsboard the persistent devices file is not updated since that name is already present in __saved_devices

```python
 def add_device(self, device_name, content, device_type=None):
     if device_name not in self.__saved_devices:
        device_type = device_type if device_type is not None else 'default'
        self.__connected_devices[device_name] = {**content, "device_type": device_type}
        self.__saved_devices[device_name] = {**content, "device_type": device_type}
        self.__save_persistent_devices()
        self.tb_client.client.gw_connect_device(device_name, device_type)
```

Can this lead to any problems? I think the correct way is to remove the deleted device from __save_devices array too, as it's done in this PR.