### PR TITLE
Fix: define pymodbus packages dependency version

### DIFF
--- a/thingsboard_gateway/connectors/modbus/modbus_connector.py
+++ b/thingsboard_gateway/connectors/modbus/modbus_connector.py
@@ -25,7 +25,7 @@ try:
     from pymodbus.constants import Defaults
 except ImportError:
     print("Modbus library not found - installing...")
-    TBUtility.install_package("pymodbus", ">=2.3.0")
+    TBUtility.install_package("pymodbus", ">=2.3.0,<3.0.0")
     TBUtility.install_package('pyserial')
     from pymodbus.constants import Defaults
 


### PR DESCRIPTION
Fix the bug of modbus connector initialization failure due to unclear definition of pymodbus version number.