### PR TITLE
opcua_asyncio: Fixes node regex + improved log messages

### DIFF
--- a/thingsboard_gateway/connectors/opcua_asyncio/device.py
+++ b/thingsboard_gateway/connectors/opcua_asyncio/device.py
@@ -37,11 +37,11 @@ class Device:
         for section in ('attributes', 'timeseries'):
             for node_config in self.config.get(section, []):
                 try:
-                    if re.search(r"(ns=\d*;[isgb]=.*\d)", node_config['path']):
-                        child = re.search(r"(ns=\d*;[isgb]=.*\d)", node_config['path'])
+                    if re.search(r"(ns=\d+;[isgb]=[^}]+)", node_config['path']):
+                        child = re.search(r"(ns=\d+;[isgb]=[^}]+)", node_config['path'])
                         self.values[section].append({'path': child.groups()[0], 'key': node_config['key']})
-                    elif re.search(r"\${([A-Za-z.:\\\d]*)}", node_config['path']):
-                        child = re.search(r"\${([A-Za-z.:\\\d]*)", node_config['path'])
+                    elif re.search(r"\${([A-Za-z.:\\\d]+)}", node_config['path']):
+                        child = re.search(r"\${([A-Za-z.:\\\d]+)", node_config['path'])
                         self.values[section].append(
                             {'path': self.path + child.groups()[0].split('\\.'), 'key': node_config['key']})
 


### PR DESCRIPTION
Most NodeId types are very loose (especially Opaque/ByteString), hence the regex should be very inclusive as well.

See https://documentation.unified-automation.com/uasdkhp/1.4.1/html/_l2_ua_node_ids.html for more information.