### PR TITLE
[WIP] Added converter update from shared attr for MQTT Connector

### DIFF
--- a/thingsboard_gateway/connectors/connector.py
+++ b/thingsboard_gateway/connectors/connector.py
@@ -49,6 +49,10 @@ class Connector(ABC):
     def server_side_rpc_handler(self, content):
         pass
 
+    @abstractmethod
+    def get_converters(self):
+        pass
+
     def is_filtering_enable(self, device_name):
         return DEFAULT_SEND_ON_CHANGE_VALUE
 

--- a/thingsboard_gateway/connectors/mqtt/json_mqtt_uplink_converter.py
+++ b/thingsboard_gateway/connectors/mqtt/json_mqtt_uplink_converter.py
@@ -31,6 +31,10 @@ class JsonMqttUplinkConverter(MqttUplinkConverter):
     def config(self):
         return self.__config
 
+    @config.setter
+    def config(self, value):
+        self.__config = value
+
     @StatisticsService.CollectStatistics(start_stat_type='receivedBytesFromDevices',
                                          end_stat_type='convertedBytesFromDevice')
     def convert(self, topic, data):

--- a/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
+++ b/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
@@ -844,6 +844,9 @@ class MqttConnector(Connector, Thread):
         log.info("RPC canceled or terminated. Unsubscribing from %s", topic)
         self._client.unsubscribe(topic)
 
+    def get_converters(self):
+        return self.__mapping_sub_topics
+
     class ConverterWorker(Thread):
         def __init__(self, name, incoming_queue, send_result):
             super().__init__()


### PR DESCRIPTION
**How does it work?**
1. Create shared attribute on the gateway:
    <img width="898" alt="зображення" src="https://user-images.githubusercontent.com/43861229/228651736-0d31d25f-f0f4-4468-aaa8-74626bc1548e.png">
    Where you have to provide the Connecter name and Converter Class Name through `:`
2. Update provided shared attribute with the new configuration:
     <img width="915" alt="зображення" src="https://user-images.githubusercontent.com/43861229/228652498-64f29a36-e59f-4546-9a74-2f23bda3904b.png">
3. On the gateway logs you will see the following message:   
     <img width="1351" alt="зображення" src="https://user-images.githubusercontent.com/43861229/228652724-b5d98706-1b7a-41d7-8a60-279fae3a5508.png">

**What else needs to be done?**
Need to be implemented for every connector following methods: `get_converters`, `config setter`