### PR TITLE
Get rid of warning while setting connector name.

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -696,7 +696,7 @@ class TBGatewayService:
                                                                                              connector_config["config"][
                                                                                                  config],
                                                                                              connector_type)
-                                    connector.setName(connector_config["name"])
+                                    connector.name = connector_config["name"]
                                     self.available_connectors[connector.get_name()] = connector
                                     connector.open()
                                 else:


### PR DESCRIPTION
Fixed `DeprecationWarning`