### PR TITLE
Changed the default converters to use local instead of class variables

### DIFF
--- a/for_build/etc/thingsboard-gateway/extensions/mqtt/custom_mqtt_uplink_converter.py
+++ b/for_build/etc/thingsboard-gateway/extensions/mqtt/custom_mqtt_uplink_converter.py
@@ -20,14 +20,14 @@ from thingsboard_gateway.connectors.mqtt.mqtt_uplink_converter import MqttUplink
 class CustomMqttUplinkConverter(MqttUplinkConverter):
     def __init__(self, config):
         self.__config = config.get('converter')
-        self.dict_result = {}
 
     def convert(self, topic, body):
         try:
-            self.dict_result["deviceName"] = topic.split("/")[
+            dict_result = {}
+            dict_result["deviceName"] = topic.split("/")[
                 -1]  # getting all data after last '/' symbol in this case: if topic = 'devices/temperature/sensor1' device name will be 'sensor1'.
-            self.dict_result["deviceType"] = "Thermostat"  # just hardcode this
-            self.dict_result["telemetry"] = []  # template for telemetry array
+            dict_result["deviceType"] = "Thermostat"  # just hardcode this
+            dict_result["telemetry"] = []  # template for telemetry array
             bytes_to_read = body.replace("0x", "")  # Replacing the 0x (if '0x' in body), needs for converting to bytearray
             converted_bytes = bytearray.fromhex(bytes_to_read)  # Converting incoming data to bytearray
             if self.__config.get("extension-config") is not None:
@@ -36,10 +36,10 @@ class CustomMqttUplinkConverter(MqttUplinkConverter):
                     for _ in range(self.__config["extension-config"][telemetry_key]):  # reading every value with value length from config
                         value = value * 256 + converted_bytes.pop(0)  # process and remove byte from processing
                     telemetry_to_send = {telemetry_key.replace("Bytes", ""): value}  # creating telemetry data for sending into Thingsboard
-                    self.dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
+                    dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
             else:
-                self.dict_result["telemetry"] = {"data": int(body, 0)}  # if no specific configuration in config file - just send data which received
-            return self.dict_result
+                dict_result["telemetry"] = {"data": int(body, 0)}  # if no specific configuration in config file - just send data which received
+            return dict_result
 
         except Exception as e:
             log.exception('Error in converter, for config: \n%s\n and message: \n%s\n', dumps(self.__config), body)

--- a/for_build/etc/thingsboard-gateway/extensions/request/custom_request_uplink_converter.py
+++ b/for_build/etc/thingsboard-gateway/extensions/request/custom_request_uplink_converter.py
@@ -23,15 +23,15 @@ from thingsboard_gateway.tb_utility.tb_utility import TBUtility
 class CustomRequestUplinkConverter(RequestConverter):
     def __init__(self, config):
         self.__config = config.get('converter')
-        self.dict_result = {}
 
     def convert(self, _, body):
         try:
             data = body["data"]["value"]
-            self.dict_result["deviceName"] = TBUtility.get_value(self.__config.get("deviceNameJsonExpression"), body, expression_instead_none=True)
-            self.dict_result["deviceType"] = TBUtility.get_value(self.__config.get("deviceTypeJsonExpression"), body, expression_instead_none=True)
-            self.dict_result["attributes"] = []
-            self.dict_result["telemetry"] = []
+            dict_result = {}
+            dict_result["deviceName"] = TBUtility.get_value(self.__config.get("deviceNameJsonExpression"), body, expression_instead_none=True)
+            dict_result["deviceType"] = TBUtility.get_value(self.__config.get("deviceTypeJsonExpression"), body, expression_instead_none=True)
+            dict_result["attributes"] = []
+            dict_result["telemetry"] = []
             converted_bytes = bytearray.fromhex(data)
             if self.__config.get("extension-config") is not None:
                 for telemetry_key in self.__config["extension-config"]:
@@ -55,11 +55,11 @@ class CustomRequestUplinkConverter(RequestConverter):
                         telemetry_to_send = {
                             telemetry_key["key"]: value}  # creating telemetry data for sending into Thingsboard
                         # current_byte_position += self.__config["extension-config"][telemetry_key]
-                        self.dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
+                        dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
             else:
-                self.dict_result["telemetry"] = {
+                dict_result["telemetry"] = {
                     "data": int(body, 0)}  # if no specific configuration in config file - just send data which received
-            return self.dict_result
+            return dict_result
 
         except Exception as e:
             log.error('Error in converter, for config: \n%s\n and message: \n%s\n', dumps(self.__config), body)

--- a/for_build/etc/thingsboard-gateway/extensions/serial/custom_serial_converter.py
+++ b/for_build/etc/thingsboard-gateway/extensions/serial/custom_serial_converter.py
@@ -18,17 +18,17 @@ from thingsboard_gateway.connectors.converter import Converter, log
 class CustomSerialUplinkConverter(Converter):
     def __init__(self, config):
         self.__config = config
-        self.result_dict = {
-            'deviceName': config.get('name', 'CustomSerialDevice'),
-            'deviceType': config.get('deviceType', 'default'),
-            'attributes': [],
-            'telemetry': []
-            }
 
     def convert(self, config, data: bytes):
+        dict_result = {
+            'deviceName': self.__config.get('name', 'CustomSerialDevice'),
+            'deviceType': self.__config.get('deviceType', 'default'),
+            'attributes': [],
+            'telemetry': []
+        }
         keys = ['attributes', 'telemetry']
         for key in keys:
-            self.result_dict[key] = []
+            dict_result[key] = []
             if self.__config.get(key) is not None:
                 for config_object in self.__config.get(key):
                     data_to_convert = data
@@ -45,6 +45,6 @@ class CustomSerialUplinkConverter(Converter):
                         from_byte = config_object.get('fromByte')
                         data_to_convert = data_to_convert[from_byte:]
                     converted_data = {config_object['key']: data_to_convert.decode('UTF-8')}
-                    self.result_dict[key].append(converted_data)
-        log.debug("Converted data: %s", self.result_dict)
-        return self.result_dict
+                    dict_result[key].append(converted_data)
+        log.debug("Converted data: %s", dict_result)
+        return dict_result

--- a/thingsboard_gateway/connectors/ble/bytes_ble_uplink_converter.py
+++ b/thingsboard_gateway/connectors/ble/bytes_ble_uplink_converter.py
@@ -34,9 +34,6 @@ from thingsboard_gateway.gateway.statistics_service import StatisticsService
 class BytesBLEUplinkConverter(BLEUplinkConverter):
     def __init__(self, config):
         self.__config = config
-        self.dict_result = {"deviceName": config['deviceName'],
-                            "deviceType": config['deviceType']
-                            }
 
     @StatisticsService.CollectStatistics(start_stat_type='receivedBytesFromDevices',
                                          end_stat_type='convertedBytesFromDevice')
@@ -44,9 +41,14 @@ class BytesBLEUplinkConverter(BLEUplinkConverter):
         if data is None:
             return {}
 
+        dict_result = {
+            "deviceName": self.__config['deviceName'],
+            "deviceType": self.__config['deviceType']
+        }
+
         try:
-            self.dict_result["telemetry"] = []
-            self.dict_result["attributes"] = []
+            dict_result["telemetry"] = []
+            dict_result["attributes"] = []
 
             for section in ('telemetry', 'attributes'):
                 for item in data[section]:
@@ -71,7 +73,7 @@ class BytesBLEUplinkConverter(BLEUplinkConverter):
                             converted_data = converted_data.replace(exp, data_to_replace)
 
                         if item.get('key') is not None:
-                            self.dict_result[section].append({item['key']: converted_data})
+                            dict_result[section].append({item['key']: converted_data})
                         else:
                             log.error('Key for %s not found in config: %s', config['type'], config[section])
                     except Exception as e:
@@ -81,5 +83,5 @@ class BytesBLEUplinkConverter(BLEUplinkConverter):
         except Exception as e:
             log.exception(e)
 
-        log.debug(self.dict_result)
-        return self.dict_result
+        log.debug(dict_result)
+        return dict_result

--- a/thingsboard_gateway/connectors/ble/hex_bytes_ble_uplink_converter.py
+++ b/thingsboard_gateway/connectors/ble/hex_bytes_ble_uplink_converter.py
@@ -8,7 +8,7 @@ from thingsboard_gateway.gateway.statistics_service import StatisticsService
 class HexBytesBLEUplinkConverter(BLEUplinkConverter):
     def __init__(self, config):
         self.__config = config
-        self.dict_result = {"deviceName": config['deviceName'],
+        dict_result = {"deviceName": config['deviceName'],
                             "deviceType": config['deviceType']
                             }
 
@@ -16,9 +16,11 @@ class HexBytesBLEUplinkConverter(BLEUplinkConverter):
         if data is None:
             return {}
 
+        dict_result = {}
+
         try:
-            self.dict_result["telemetry"] = []
-            self.dict_result["attributes"] = []
+            dict_result["telemetry"] = []
+            dict_result["attributes"] = []
 
             for section in ('telemetry', 'attributes'):
                 for item in config[section]:
@@ -43,7 +45,7 @@ class HexBytesBLEUplinkConverter(BLEUplinkConverter):
                                 value = eval(item['compute'], globals(), {'value': value})
 
                         if item.get('key') is not None:
-                            self.dict_result[section].append({item['key']: value})
+                            dict_result[section].append({item['key']: value})
                         else:
                             log.error('Key for %s not found in config: %s', config['type'], config[section])
                     except Exception as e:
@@ -52,5 +54,5 @@ class HexBytesBLEUplinkConverter(BLEUplinkConverter):
         except Exception as e:
             log.exception(e)
 
-        log.debug(self.dict_result)
-        return self.dict_result
+        log.debug(dict_result)
+        return dict_result

--- a/thingsboard_gateway/connectors/socket/bytes_socket_uplink_converter.py
+++ b/thingsboard_gateway/connectors/socket/bytes_socket_uplink_converter.py
@@ -19,7 +19,7 @@ from thingsboard_gateway.gateway.statistics_service import StatisticsService
 class BytesSocketUplinkConverter(SocketUplinkConverter):
     def __init__(self, config):
         self.__config = config
-        self.dict_result = {
+        dict_result = {
             "deviceName": config['deviceName'],
             "deviceType": config['deviceType']
         }
@@ -30,9 +30,14 @@ class BytesSocketUplinkConverter(SocketUplinkConverter):
         if data is None:
             return {}
 
+        dict_result = {
+            "deviceName": self.__config['deviceName'],
+            "deviceType": self.__config['deviceType']
+        }
+
         try:
-            self.dict_result["telemetry"] = []
-            self.dict_result["attributes"] = []
+            dict_result["telemetry"] = []
+            dict_result["attributes"] = []
 
             for section in ('telemetry', 'attributes'):
                 for item in config[section]:
@@ -49,7 +54,7 @@ class BytesSocketUplinkConverter(SocketUplinkConverter):
                             converted_data = str(converted_data)
 
                         if item.get('key') is not None:
-                            self.dict_result[section].append(
+                            dict_result[section].append(
                                 {item['key']: converted_data})
                         else:
                             log.error('Key for %s not found in config: %s', config['type'], config['section_config'])
@@ -58,5 +63,5 @@ class BytesSocketUplinkConverter(SocketUplinkConverter):
         except Exception as e:
             log.exception(e)
 
-        log.debug(self.dict_result)
-        return self.dict_result
+        log.debug(dict_result)
+        return dict_result

--- a/thingsboard_gateway/extensions/mqtt/custom_mqtt_uplink_converter.py
+++ b/thingsboard_gateway/extensions/mqtt/custom_mqtt_uplink_converter.py
@@ -20,7 +20,6 @@ from thingsboard_gateway.connectors.mqtt.mqtt_uplink_converter import MqttUplink
 class CustomMqttUplinkConverter(MqttUplinkConverter):
     def __init__(self, config):
         self.__config = config.get('converter')
-        self.dict_result = {}
 
     @property
     def config(self):
@@ -28,10 +27,11 @@ class CustomMqttUplinkConverter(MqttUplinkConverter):
 
     def convert(self, topic, body):
         try:
-            self.dict_result["deviceName"] = topic.split("/")[
+            dict_result = {}
+            dict_result["deviceName"] = topic.split("/")[
                 -1]  # getting all data after last '/' symbol in this case: if topic = 'devices/temperature/sensor1' device name will be 'sensor1'.
-            self.dict_result["deviceType"] = "Thermostat"  # just hardcode this
-            self.dict_result["telemetry"] = []  # template for telemetry array
+            dict_result["deviceType"] = "Thermostat"  # just hardcode this
+            dict_result["telemetry"] = []  # template for telemetry array
             bytes_to_read = body.replace("0x", "")  # Replacing the 0x (if '0x' in body), needs for converting to bytearray
             converted_bytes = bytearray.fromhex(bytes_to_read)  # Converting incoming data to bytearray
             if self.__config.get("extension-config") is not None:
@@ -40,10 +40,10 @@ class CustomMqttUplinkConverter(MqttUplinkConverter):
                     for _ in range(self.__config["extension-config"][telemetry_key]):  # reading every value with value length from config
                         value = value * 256 + converted_bytes.pop(0)  # process and remove byte from processing
                     telemetry_to_send = {telemetry_key.replace("Bytes", ""): value}  # creating telemetry data for sending into Thingsboard
-                    self.dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
+                    dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
             else:
-                self.dict_result["telemetry"] = {"data": int(body, 0)}  # if no specific configuration in config file - just send data which received
-            return self.dict_result
+                dict_result["telemetry"] = {"data": int(body, 0)}  # if no specific configuration in config file - just send data which received
+            return dict_result
 
         except Exception as e:
             log.exception('Error in converter, for config: \n%s\n and message: \n%s\n', dumps(self.__config), body)

--- a/thingsboard_gateway/extensions/request/custom_request_uplink_converter.py
+++ b/thingsboard_gateway/extensions/request/custom_request_uplink_converter.py
@@ -23,15 +23,15 @@ from thingsboard_gateway.tb_utility.tb_utility import TBUtility
 class CustomRequestUplinkConverter(RequestConverter):
     def __init__(self, config):
         self.__config = config.get('converter')
-        self.dict_result = {}
 
     def convert(self, _, body):
         try:
             data = body["data"]["value"]
-            self.dict_result["deviceName"] = TBUtility.get_value(self.__config.get("deviceNameJsonExpression"), body, expression_instead_none=True)
-            self.dict_result["deviceType"] = TBUtility.get_value(self.__config.get("deviceTypeJsonExpression"), body, expression_instead_none=True)
-            self.dict_result["attributes"] = []
-            self.dict_result["telemetry"] = []
+            dict_result = {}
+            dict_result["deviceName"] = TBUtility.get_value(self.__config.get("deviceNameJsonExpression"), body, expression_instead_none=True)
+            dict_result["deviceType"] = TBUtility.get_value(self.__config.get("deviceTypeJsonExpression"), body, expression_instead_none=True)
+            dict_result["attributes"] = []
+            dict_result["telemetry"] = []
             converted_bytes = bytearray.fromhex(data)
             if self.__config.get("extension-config") is not None:
                 for telemetry_key in self.__config["extension-config"]:
@@ -55,11 +55,11 @@ class CustomRequestUplinkConverter(RequestConverter):
                         telemetry_to_send = {
                             telemetry_key["key"]: value}  # creating telemetry data for sending into Thingsboard
                         # current_byte_position += self.__config["extension-config"][telemetry_key]
-                        self.dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
+                        dict_result["telemetry"].append(telemetry_to_send)  # adding data to telemetry array
             else:
-                self.dict_result["telemetry"] = {
+                dict_result["telemetry"] = {
                     "data": int(body, 0)}  # if no specific configuration in config file - just send data which received
-            return self.dict_result
+            return dict_result
 
         except Exception as e:
             log.error('Error in converter, for config: \n%s\n and message: \n%s\n', dumps(self.__config), body)

--- a/thingsboard_gateway/extensions/serial/custom_serial_converter.py
+++ b/thingsboard_gateway/extensions/serial/custom_serial_converter.py
@@ -18,17 +18,17 @@ from thingsboard_gateway.connectors.converter import Converter, log
 class CustomSerialUplinkConverter(Converter):
     def __init__(self, config):
         self.__config = config
-        self.result_dict = {
-            'deviceName': config.get('name', 'CustomSerialDevice'),
-            'deviceType': config.get('deviceType', 'default'),
-            'attributes': [],
-            'telemetry': []
-            }
 
     def convert(self, config, data: bytes):
+        dict_result = {
+            'deviceName': self.__config.get('name', 'CustomSerialDevice'),
+            'deviceType': self.__config.get('deviceType', 'default'),
+            'attributes': [],
+            'telemetry': []
+        }        
         keys = ['attributes', 'telemetry']
         for key in keys:
-            self.result_dict[key] = []
+            dict_result[key] = []
             if self.__config.get(key) is not None:
                 for config_object in self.__config.get(key):
                     data_to_convert = data
@@ -45,6 +45,6 @@ class CustomSerialUplinkConverter(Converter):
                         from_byte = config_object.get('fromByte')
                         data_to_convert = data_to_convert[from_byte:]
                     converted_data = {config_object['key']: data_to_convert.decode('UTF-8')}
-                    self.result_dict[key].append(converted_data)
-        log.debug("Converted data: %s", self.result_dict)
-        return self.result_dict
+                    dict_result[key].append(converted_data)
+        log.debug("Converted data: %s", dict_result)
+        return dict_result

--- a/thingsboard_gateway/grpc_connectors/socket/bytes_socket_uplink_converter.py
+++ b/thingsboard_gateway/grpc_connectors/socket/bytes_socket_uplink_converter.py
@@ -18,15 +18,16 @@ from thingsboard_gateway.connectors.socket.socket_uplink_converter import Socket
 class BytesGrpcSocketUplinkConverter(SocketUplinkConverter):
     def __init__(self, config):
         self.__config = config
-        self.dict_result = {}
 
     def convert(self, config, data):
         if data is None:
             return {}
 
+        dict_result = {}
+
         try:
-            self.dict_result["telemetry"] = {}
-            self.dict_result["attributes"] = {}
+            dict_result["telemetry"] = {}
+            dict_result["attributes"] = {}
 
             for section in ('telemetry', 'attributes'):
                 for item in config[section]:
@@ -43,7 +44,7 @@ class BytesGrpcSocketUplinkConverter(SocketUplinkConverter):
                             converted_data = str(converted_data)
 
                         if item.get('key') is not None:
-                            self.dict_result[section][item['key']] = converted_data
+                            dict_result[section][item['key']] = converted_data
                         else:
                             log.error('Key for %s not found in config: %s', config['type'], config['section_config'])
                     except Exception as e:
@@ -51,5 +52,5 @@ class BytesGrpcSocketUplinkConverter(SocketUplinkConverter):
         except Exception as e:
             log.exception(e)
 
-        log.debug(self.dict_result)
-        return self.dict_result
+        log.debug(dict_result)
+        return dict_result


### PR DESCRIPTION
Fix as indicated in #1103 

The value returned by a converter must not be a reference to a static variable. Instead, in this project the default converters use a class variable (`self.dict_result`) to process the received message, and return it at the end. 

So if 2 different messages are queued in `__converted_data_queue` while `__send_to_storage` thread is in its 0.2s sleep, when it wakes up it found a queue of size 2 but both elements have the same reference, whose value is both times the last value assigned to that variable (the last converted message).

The solution is to use a local variable inside the convert function (`dict_result` instead of `self.dict_result`).