### PR TITLE
Fix a race condition in the Sqlite storage which caused all data to stop

### DIFF
--- a/thingsboard_gateway/storage/sqlite/sqlite_event_storage.py
+++ b/thingsboard_gateway/storage/sqlite/sqlite_event_storage.py
@@ -75,7 +75,6 @@ class SQLiteEventStorage(EventStorage):
 
                 log.info("Sending data to storage")
                 self.processQueue.put(request)
-                self.db.process()
                 return True
             else:
                 return False


### PR DESCRIPTION
If `Database.process` called from `SQLiteEventStorage.put` handled the request then everything worked. If the `Database.process` running in the `Database` thread handled it then the `Database.process` called from `SQLiteEventStorage.put` would stall waiting for a request to handle.