### PR TITLE
Meraki Sensors Timeseries 

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -12,6 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+import datetime
 import logging
 import logging.config
 import logging.handlers
@@ -984,8 +985,14 @@ class TBGatewayService:
                 if isinstance(item['ts'], int):
                     telemetry_with_ts.append({"ts": item["ts"], "values": {**item["values"]}})
                 else:
-                    log.warning('Data has invalid TS (timestamp) format! Using generated TS instead.')
-                    telemetry_with_ts.append({"ts": int(time() * 1000), "values": {**item["values"]}})
+                    try:
+                        dt_obj = datetime.datetime.strptime(item["ts"], '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc)
+                        timestamp = int(dt_obj.timestamp() * 1000)
+                        telemetry_with_ts.append({"ts": timestamp, "values": {**item["values"]}})
+                        log.warning('Data has string TS (timestamp) format! Convert to integer.')
+                    except:
+                        log.warning('Data has invalid TS (timestamp) format! Using generated TS instead.')
+                        telemetry_with_ts.append({"ts": int(time() * 1000), "values": {**item["values"]}})
 
         if telemetry_with_ts:
             data["telemetry"] = telemetry_with_ts


### PR DESCRIPTION
Hi,
I have a problem with meraki sensors.
In fact, when their telemetries are sent back to the gateway, timestamps are not kept because they are provided as defined in RFC3339 (aka. 2023-10-23T15:00:00Z).
I therefore lose the history of these metrics.
Other types of timestamp format should be taken into account.