### PR TITLE
Refresh `sys.path` after lib install

### DIFF
--- a/thingsboard_gateway/tb_utility/tb_utility.py
+++ b/thingsboard_gateway/tb_utility/tb_utility.py
@@ -141,6 +141,8 @@ class TBUtility:
     def install_package(package, version="upgrade", force_install=False):
         from sys import executable
         from subprocess import check_call, CalledProcessError
+        import site
+        from importlib import reload
         result = False
 
         if force_install:
@@ -168,6 +170,13 @@ class TBUtility:
                         [executable, "-m", "pip", "install", package + installation_sign + version, "--user"])
                 except CalledProcessError:
                     result = check_call([executable, "-m", "pip", "install", package + installation_sign + version])
+
+        # Because `pip` is running in a subprocess the newly installed modules and libraries are
+        # not immediately available to the current runtime. 
+        # Refreshing sys.path fixes this. See:
+        # https://stackoverflow.com/questions/4271494/what-sets-up-sys-path-with-python-and-when
+        reload(site)
+
         return result
 
     @staticmethod


### PR DESCRIPTION
Resolves: https://github.com/thingsboard/thingsboard-gateway/issues/1227, https://github.com/thingsboard/thingsboard-gateway/issues/1221

## Scope

This tries to make progress on the error described in https://github.com/thingsboard/thingsboard-gateway/issues/1221

The root cause seems to be that after `pip install` in a subprocess the module in not added to the "context" in which the script was initially started in. Users hence have to "restart" the script to make the module discoverabled.

I found a way where this restart is no necessary which is essentially a copy from here:

- https://stackoverflow.com/a/24773951
- https://docs.python.org/3/library/site.html 

## Test Procedure

This is how I tested my changes:

```sh
docker build -t local-gateway docker && docker run local-gateway
```
