### PR TITLE
fixbug:the rpc request in progress got replaced by the new rpc request

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -453,6 +453,7 @@ class TBGatewayService:
                         new_rpc_request_in_progress = {key: value for key, value in
                                                        self.__rpc_requests_in_progress.items() if value != 'del'}
                     if not self.__rpc_register_queue.empty():
+                        new_rpc_request_in_progress = self.__rpc_requests_in_progress
                         rpc_request_from_queue = self.__rpc_register_queue.get(False)
                         topic = rpc_request_from_queue["topic"]
                         data = rpc_request_from_queue["data"]


### PR DESCRIPTION
A little bit confused, is it designed to allow only one rpc at any given time?
If multi rpc are allowed, then even code got fixed with this pull request,  if two rpc lauched for the same control but different device with the same topic, the rpc request in progress still got overlapped.