### PR TITLE
Reduce len check on config keys

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -787,7 +787,7 @@ class TBGatewayService:
                             connector = None
                             connector_name = None
                             try:
-                                if connector_config["config"][config] is not None and len(connector_config["config"][config].keys()) > 2:
+                                if connector_config["config"][config] is not None and len(connector_config["config"][config].keys()) > 1:
                                     connector_name = connector_config["name"]
 
                                     if not self.available_connectors.get(connector_name):


### PR DESCRIPTION
Reduced the len check from 2 to 1 because this can make a custom connector invisible.
As an example, if someone modified the OPCUA connector (that has only 1 root key) and doesn't add anything at the root level, then the number of keys at that point would be =2 (because in previous steps the name is added), which makes the check fail and the config "not found or empty".