### PR TITLE
opcua: Fixes issues with computing "information" based on path

### DIFF
--- a/tests/connectors/opcua/test_opcua_connector.py
+++ b/tests/connectors/opcua/test_opcua_connector.py
@@ -1,0 +1,34 @@
+import logging
+import unittest
+from unittest import mock
+
+from opcua import Node
+from opcua.ua import FourByteNodeId
+
+from thingsboard_gateway.connectors.opcua.opcua_connector import OpcUaConnector
+
+logging.basicConfig(level=logging.ERROR,
+                    format='%(asctime)s - %(levelname)s - %(module)s - %(lineno)d - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S')
+log = logging.getLogger("root")
+
+EMPTY_CONFIG = {'server': {'mapping': [], 'url': 'opc.tcp://localhost:4840'}}
+
+class TestOpcUaConnector(unittest.TestCase):
+    def test_check_path_browsepath_partial(self):
+        connector = OpcUaConnector(None, EMPTY_CONFIG, None)
+        with mock.patch.object(OpcUaConnector, 'get_node_path', return_value='Root\\.Objects\\.Machine'):
+            result = connector._check_path('Cycle\\.Cycle\\Status', Node(nodeid=FourByteNodeId("ns=2;i=1"), server=None))
+            self.assertEqual(result, 'Root\\\\.Objects\\\\.Machine\\\\.Cycle\\\\.Cycle\\\\Status')
+
+    def test_check_path_browsepath_partial_with_path_seperator(self):
+        connector = OpcUaConnector(None, EMPTY_CONFIG, None)
+        with mock.patch.object(OpcUaConnector, 'get_node_path', return_value='Root\\.Objects\\.Machine'):
+            result = connector._check_path('\\.Cycle\\.Cycle\\Status', Node(nodeid=FourByteNodeId("ns=2;i=1"), server=None))
+            self.assertEqual(result, 'Root\\\\.Objects\\\\.Machine\\\\.Cycle\\\\.Cycle\\\\Status')
+
+    def test_check_path_browsepath_full(self):
+        connector = OpcUaConnector(None, EMPTY_CONFIG, None)
+        with mock.patch.object(OpcUaConnector, 'get_node_path', return_value='Root\\.Objects\\.Machine'):
+            result = connector._check_path('Root\\.Objects\\.Machine\\.Cycle\\.Cycle\\Status', Node(nodeid=FourByteNodeId("ns=2;i=1"), server=None))
+            self.assertEqual(result, 'Root\\\\.Objects\\\\.Machine\\\\.Cycle\\\\.Cycle\\\\Status')

--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -685,13 +685,13 @@ class OpcUaConnector(Thread, Connector):
         if re.search(r"^root", config_path.lower()) is None:
             node_path = self.get_node_path(node)
             # node_path = '\\\\.'.join(char.split(":")[1] for char in node.get_path(200000, True))
-            if config_path[-3:] != '\\.':
-                information_path = (node_path + '\\.' + config_path).replace('\\', '\\\\')
+            if config_path[:2] != '\\.':
+                information_path = node_path + '\\.' + config_path
             else:
-                information_path = node_path + config_path.replace('\\', '\\\\')
+                information_path = node_path + config_path
         else:
             information_path = config_path
-        result = information_path[:]
+        result = information_path[:].replace('\\', '\\\\')
         return result
 
     @property

--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -691,8 +691,7 @@ class OpcUaConnector(Thread, Connector):
                 information_path = node_path + config_path
         else:
             information_path = config_path
-        result = information_path[:].replace('\\', '\\\\')
-        return result
+        return information_path.replace('\\', '\\\\')
 
     @property
     def subscribed(self):

--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -36,9 +36,9 @@ except ImportError:
     TBUtility.install_package("opcua")
     from opcua import Client, Node, ua
 
-try:   
+try:
     from opcua.crypto import uacrypto
-except ImportError: 
+except ImportError:
     TBUtility.install_package("cryptography")
     from opcua.crypto import uacrypto
 
@@ -414,6 +414,8 @@ class OpcUaConnector(Thread, Connector):
                 information["path"] = '${%s}' % information_path
                 information_nodes = []
                 self.__search_node(device_info["deviceNode"], information_path, result=information_nodes)
+                if len(information_nodes) == 0:
+                    self._log.error("No nodes found for: %s - %s -  %s", information_type, information["key"], information_path)
 
                 for information_node in information_nodes:
                     changed_key = False
@@ -440,8 +442,8 @@ class OpcUaConnector(Thread, Connector):
                             converter = device_info["uplink_converter"]
 
                         self.subscribed[information_node] = {"converter": converter,
-                                                             "path": information_path,
-                                                             "config_path": config_path}
+                                                             "information": information,
+                                                             "information_type": information_type}
 
                         # Use Node name if param "key" not found in config
                         if not information.get('key'):
@@ -460,7 +462,7 @@ class OpcUaConnector(Thread, Connector):
                         if not device_info.get(information_types[information_type]):
                             device_info[information_types[information_type]] = []
 
-                        converted_data = converter.convert((config_path, information_path), information_value)
+                        converted_data = converter.convert((information, information_type), information_value)
                         self.statistics['MessagesReceived'] = self.statistics['MessagesReceived'] + 1
                         self.data_to_send.append(converted_data)
                         self.statistics['MessagesSent'] = self.statistics['MessagesSent'] + 1
@@ -470,7 +472,7 @@ class OpcUaConnector(Thread, Connector):
                             sub_nodes.append(information_node)
                     else:
                         self._log.error("Node for %s \"%s\" with path %s - NOT FOUND!", information_type,
-                                        information_key, information_path)
+                                        information['key'], information_path)
 
                     if changed_key:
                         information['key'] = None
@@ -729,8 +731,8 @@ class SubHandler(object):
         try:
             self.connector._log.debug("Python: New data change event on node %s, with val: %s and data %s", node, val, str(data))
             subscription = self.connector.subscribed[node]
-            converted_data = subscription["converter"].convert((subscription["config_path"], subscription["path"]), val,
-                                                               data, key=subscription.get('key'))
+            converted_data = subscription["converter"].convert(
+                (subscription["information"], subscription["information_type"]), val, data, key=subscription.get('key'))
             self.connector.statistics['MessagesReceived'] = self.connector.statistics['MessagesReceived'] + 1
             self.connector.data_to_send.append(converted_data)
             self.connector.statistics['MessagesSent'] = self.connector.statistics['MessagesSent'] + 1


### PR DESCRIPTION
### Bugfix

Timeseries with nodeid paths containing `\\` in the string part failed with `re.error bad escape \... at position ...`. The `fullmatch(path, config)` would compile the `path` part as a regex, but cannot be assumed to be correctly escaped (hence the `re.error`). Upon closer inspection the rather complicated code can be removed completely by storing the `information` with the subscription when it is first made. Functionality from configuration pov should be unchanged/equivalent.

Test configuration:
```
        "timeseries": [
          {
            "key": "MachineRt_Error_Status",
            "path": "${ns=2;s=MachineRt\\Error\\Status}"
          },{
            "key": "MachineRt_Cycle_Status",
            "path": "${ns=2;s=MachineRt\\Cycle\\Status}"
          }]
```

Tested with several small OPCUA servers.