### PR TITLE
Fix issue 1316 and 1326

### DIFF
--- a/thingsboard_gateway/tb_utility/tb_utility.py
+++ b/thingsboard_gateway/tb_utility/tb_utility.py
@@ -245,13 +245,16 @@ class TBUtility:
             return data
 
         evaluated_data = eval(data, globals(), {}) if use_eval else data
-        if 'int' in new_type or 'long' in new_type:
-            return int(float(evaluated_data))
-        elif 'float' == new_type or 'double' == new_type:
-            return float(evaluated_data)
-        elif 'bool' in new_type:
-            return bool(strtobool(evaluated_data))
-        else:
+        try:
+            if 'int' in new_type or 'long' in new_type:
+                return int(float(evaluated_data))
+            elif 'float' == new_type or 'double' == new_type:
+                return float(evaluated_data)
+            elif 'bool' in new_type:
+                return bool(strtobool(evaluated_data))
+            else:
+                return str(evaluated_data)
+        except ValueError:
             return str(evaluated_data)
 
     @staticmethod


### PR DESCRIPTION
This will fix issue #1316  and #1326 so that you can parse json paths with colons in key names with the json converter and data converion to bool is working as well based on the string value like `True` or `False`