### PR TITLE
Allow filtering keys with dashes (-)

### DIFF
--- a/thingsboard_gateway/tb_utility/tb_utility.py
+++ b/thingsboard_gateway/tb_utility/tb_utility.py
@@ -135,7 +135,7 @@ class TBUtility:
 
     @staticmethod
     def get_values(expression, body=None, value_type="string", get_tag=False, expression_instead_none=False):
-        expression_arr = findall(r'\$\{[${A-Za-z0-9. ^\]\[*_:"]*\}', expression)
+        expression_arr = findall(r'\$\{[${A-Za-z0-9. ^\]\[*_:"-]*\}', expression)
 
         values = [TBUtility.get_value(exp, body, value_type=value_type, get_tag=get_tag,
                                       expression_instead_none=expression_instead_none) for exp in expression_arr]


### PR DESCRIPTION
Data of devices that use a dash in the key of the JSON payload can not be properly extracted at the moment, as the regular expression does not allow dashes. 

A concrete example: We have devices reading data from smart meters, which send OBIS codes as key.
Example OBIS code: 1-0:1.8.0
