### PR TITLE
Fix sqlite database is locked

### DIFF
--- a/thingsboard_gateway/storage/sqlite/database.py
+++ b/thingsboard_gateway/storage/sqlite/database.py
@@ -123,6 +123,7 @@ class Database(Thread):
     def delete_data(self, ts):
         try:
             data = self.db.execute('''DELETE FROM messages WHERE timestamp <= ?;''', [ts,])
+            self.db.commit()
             return data
         except Exception as e:
             self.db.rollback()
@@ -132,6 +133,7 @@ class Database(Thread):
         try:
             ts = (datetime.datetime.now() - datetime.timedelta(days=days)).timestamp()
             data = self.db.execute('''DELETE FROM messages WHERE timestamp <= ? ;''', [ts])
+            self.db.commit()
             return data
         except Exception as e:
             self.db.rollback()

--- a/thingsboard_gateway/tb_utility/tb_gateway_remote_configurator.py
+++ b/thingsboard_gateway/tb_utility/tb_gateway_remote_configurator.py
@@ -343,6 +343,7 @@ class RemoteConfigurator:
         old_event_storage = self._gateway._event_storage
         try:
             storage_class = self._gateway.event_storage_types[config["type"]]
+            self._gateway._event_storage.stop()
             self._gateway._event_storage = storage_class(config)
         except Exception as e:
             LOG.error('Something went wrong with applying the new storage configuration. Reverting...')


### PR DESCRIPTION
If a record already exists in the db messages table, then it first executes the delete sql but does not commit yet, then starts another SQLiteEventStorage instance at [#tb_gateway_remote_configurator.py:346](https://github.com/thingsboard/thingsboard-gateway/blob/36c04c290cf55096ac562032e16b15711897558f/thingsboard_gateway/tb_utility/tb_gateway_remote_configurator.py#L346)  i.e., another sqlite database connection, and again executes the the same delete sql, so the result is a locked database exception.

This exception can be avoided by adding either `self.db.commit()` or `self._gateway._event_storage.stop()`.

![image](https://github.com/user-attachments/assets/960d0ba5-2816-4873-aa08-a00a0ba813f3)


I think this could also solve this issue: https://github.com/thingsboard/thingsboard-gateway/issues/1446#issue-2381660977

