### PR TITLE
custom rpc execution

### DIFF
--- a/for_build/DEBIAN/postinst
+++ b/for_build/DEBIAN/postinst
@@ -16,14 +16,29 @@ if [ ! -d "/var/lib/thingsboard_gateway/" ]; then
     echo "Creating /var/lib/thingsboard_gateway/ directory..."
     mkdir -p /var/lib/thingsboard_gateway/
 else
-    echo "/var/lib/thingsboard_gateway/ already exists."
+    echo "/var/lib/thingsboardes_gateway/ already exists."
+fi
+echo "Checking if /etc/thingsboard-gateway/extensions exists..."
+if [ ! -d "/etc/thingsboard-gateway/extensions" ]; then
+    sudo mkdir -p /etc/thingsboard-gateway/extensions
+    echo "Created /etc/thingsboard-gateway/extensions directory"
+else
+    echo "/etc/thingsboard-gateway/extensions directory already exists. Skipping creation."
+fi
+
+echo "Checking if /etc/thingsboard-gateway/rpc exists..."
+if [ ! -d "/etc/thingsboard-gateway/rpc" ]; then
+    sudo mkdir -p /etc/thingsboard-gateway/rpc
+    echo "Created /etc/thingsboard-gateway/rpc directory"
+else
+    echo "/etc/thingsboard-gateway/rpc directory already exists. Skipping creation."
 fi
 
 # Copy necessary files and set permissions
-echo "Copying extensions to /var/lib/thingsboard_gateway/..."
-sudo cp -a -r /etc/thingsboard-gateway/extensions /var/lib/thingsboard_gateway/
-echo "Removing /etc/thingsboard-gateway/extensions..."
-sudo rm -r /etc/thingsboard-gateway/extensions
+echo "Copying extensions to /etc/thingsboard-gateway/extensions/..."
+sudo cp -a -r  /var/lib/thingsboard_gateway/extensions /etc/thingsboard-gateway/extensions
+echo "Removing /var/lib/thingsboard-gateway/extensions..."
+sudo rm -r /var/lib/thingsboard_gateway/extensions
 
 echo "Adding users to dialout and thingsboard_gateway groups..."
 sudo usermod -a -G dialout $USER

--- a/for_build/DEBIAN/preinst
+++ b/for_build/DEBIAN/preinst
@@ -25,13 +25,15 @@ else
     echo "/etc/thingsboard-gateway directory already exists. Skipping creation."
 fi
 
-# Check if the user exists before adding it
-if id "thingsboard_gateway" &>/dev/null; then
+echo "Adding non-root user"
+# check if the user exists
+if id "thingsboard_gateway" >/dev/null 2>&1; then
     echo "User 'thingsboard_gateway' already exists. Skipping user creation."
 else
     sudo adduser --system --gecos "ThingsBoard-Gateway Service" --disabled-password --group --home /var/lib/thingsboard_gateway thingsboard_gateway
     echo "Created user 'thingsboard_gateway'"
 fi
+
 
 # Check if the directory for extensions exists before creating it
 if [ ! -d "/var/lib/thingsboard_gateway/extensions" ]; then

--- a/generate_deb_package.sh
+++ b/generate_deb_package.sh
@@ -12,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-CURRENT_VERSION=$( grep -Po 'VERSION[ ,]=[ ,]\"\K(([0-9])+(\.){0,1})+' version.py )
+CURRENT_VERSION=$( grep -Po 'VERSION[ ,]=[ ,]\"\K(([0-9])+(\.){0,1})+' thingsboard_gateway/version.py )
 if [ "$1" = "clean" ] || [ "$1" = "only_clean" ] ; then
   sudo rm -rf /var/log/thingsboard-gateway/
   sudo rm -rf /var/lib/thingsboard_gateway/
@@ -94,4 +94,5 @@ EOT
   ar r ../python3-thingsboard-gateway.deb debian-binary control.tar.xz data.tar.xz
   cd ..
   rm -r deb-temp
+fi
 fi

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
               'thingsboard_gateway.extensions.socket', 'thingsboard_gateway.extensions.xmpp', 'thingsboard_gateway.gateway.statistics'
               ],
     install_requires=[
+        'setuptools',
         'cryptography',
         'jsonpath-rw',
         'regex',

--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -29,7 +29,7 @@ from sys import argv, executable
 from threading import RLock, Thread, main_thread, current_thread
 from time import sleep, time, monotonic
 from typing import Union, List
-
+import importlib.util
 from simplejson import JSONDecodeError, dumps, load, loads
 from yaml import safe_load
 
@@ -102,6 +102,7 @@ DEFAULT_DEVICE_FILTER = {
     'enable': False
 }
 
+CUSTOM_RPC_DIR = "/etc/thingsboard-gateway/rpc"
 
 def load_file(path_to_file):
     with open(path_to_file, 'r') as target_file:
@@ -351,6 +352,7 @@ class TBGatewayService:
             "device_renamed": self.__process_renamed_gateway_devices,
             "device_deleted": self.__process_deleted_gateway_devices,
         }
+        self.load_custom_rpc_methods(CUSTOM_RPC_DIR)
         self.__rpc_scheduled_methods_functions = {
             "restart": {"function": execv, "arguments": (executable, [executable.split(pathsep)[-1]] + argv)},
             "reboot": {"function": subprocess.call, "arguments": (["shutdown", "-r", "-t", "0"],)},
@@ -1997,6 +1999,35 @@ class TBGatewayService:
     def is_latency_metrics_enabled(self):
         return self.__latency_debug_mode
 
+    # custom rpc method ---------------
+    def load_custom_rpc_methods(self, folder_path):
+        """
+        Dynamically load custom RPC methods from the specified folder.
+        """
+        if not os.path.exists(folder_path):
+            return
+
+        for filename in os.listdir(folder_path):
+            if filename.endswith(".py"):
+                module_name = filename[:-3]
+                module_path = os.path.join(folder_path, filename)
+                self.import_custom_rpc_methods(module_name, module_path)
+
+    def import_custom_rpc_methods(self, module_name, module_path):
+        """
+        Import custom RPC methods from a given Python file.
+        """
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        custom_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(custom_module)
+
+        # Iterate through the attributes of the module
+        for attr_name in dir(custom_module):
+            attr = getattr(custom_module, attr_name)
+            # Check if the attribute is a function
+            if callable(attr):
+                # Add the method to the __gateway_rpc_methods dictionary
+                self.__gateway_rpc_methods[attr_name.replace("__rpc_", "")] = attr.__get__(self)
 
 if __name__ == '__main__':
     TBGatewayService(

--- a/thingsboard_gateway/version.py
+++ b/thingsboard_gateway/version.py
@@ -11,5 +11,4 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-
 VERSION = "3.5.3"


### PR DESCRIPTION
Hello,

I’d like to contribute to the custom RPC importing functionality for the gateway.

For a long time, I've wanted to enhance the gateway by adding more RPC methods that can be used for local network hardware communication or third-party integration, without exposing the rpcRemoteShell feature. This will provide a secure and controlled way to manage the gateway remotely.

Additionally, I’ve included some minor fixes related to the generation of the .deb package.

