### PR TITLE
[FIX] Use path separator, instead of separator of paths.

### DIFF
--- a/thingsboard_gateway/tb_utility/tb_handler.py
+++ b/thingsboard_gateway/tb_utility/tb_handler.py
@@ -172,7 +172,7 @@ class TimedRotatingFileHandler(logging.handlers.TimedRotatingFileHandler):
                  encoding=None, delay=False, utc=False):
         config_path = environ.get('TB_GW_LOGS_PATH')
         if config_path:
-            filename = config_path + os.pathsep + filename.split(os.pathsep)[-1]
+            filename = config_path + os.sep + filename.split(os.sep)[-1]
 
         if not Path(filename).exists():
             with open(filename, 'w'):


### PR DESCRIPTION
In case of using `TB_GW_LOGS_PATH` env variable, wrong log filename is constructed 