### PR TITLE
Exclude everything except needed files from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,14 @@
-!/.github/
-!/.git/
-!/.idea/
+# ignore everyhting
+*
+
+# except the following
+!/thingsboard_gateway/
+!LICENSE
+!README.md
+!setup.py
+!requirements.txt
+
+# ignore on every level
+**/__pycache__/
+**/*.py[cod]
+**/logs/


### PR DESCRIPTION
The rules currently defined in the .dockerignore file do not exclude anything. You can check it with:
```sh
docker run --rm --entrypoint /bin/bash thingsboard/tb-gateway:latest -c 'ls -la /'
```

![image](https://github.com/user-attachments/assets/5dcff674-c1e0-42d4-a059-e37c05da8949)

This PR fixes [#1590](https://github.com/thingsboard/thingsboard-gateway/issues/1590).
```sh
docker run --rm --entrypoint /bin/bash mbotezatu/tb-gateway:latest -c 'ls -la /'
```

![image](https://github.com/user-attachments/assets/878c6ff0-a41b-4288-b3c7-72a2b588152d)
