### PR TITLE
Update pymodbus version to 3.0.2; Fix missing start of modbus serial server

### DIFF
--- a/thingsboard_gateway/connectors/modbus/modbus_connector.py
+++ b/thingsboard_gateway/connectors/modbus/modbus_connector.py
@@ -35,7 +35,7 @@ from thingsboard_gateway.tb_utility.tb_logger import init_logger
 
 # Try import Pymodbus library or install it and import
 installation_required = False
-required_version = '3.0.0'
+required_version = '3.0.2'
 force_install = False
 
 try:

--- a/thingsboard_gateway/connectors/modbus/server.py
+++ b/thingsboard_gateway/connectors/modbus/server.py
@@ -109,6 +109,9 @@ class Server(Thread):
             self.__server = await SLAVE_TYPE[self.__type](identity=self.__identity, context=self.__server_context,
                                                           **self.__connection_config, defer_start=True,
                                                           allow_reuse_address=True, allow_reuse_port=True)
+            
+            if self.__config[TYPE_PARAMETER] == SERIAL_CONNECTION_TYPE_PARAMETER:
+                await self.__server.start()
             await self.__server.serve_forever()
         except Exception as e:
             self.__stopped = True


### PR DESCRIPTION
This PR updates pymodbus version to 3.0.2 (version 3.0.0 don't work as serial server), and add a missing start on the modbus serial server.

This partially fixes [#1672 ](https://github.com/thingsboard/thingsboard-gateway/issues/1672).