### PR TITLE
Add useReceivedTs option for consistent timestamp handling

### DIFF
--- a/thingsboard_gateway/connectors/mqtt/json_mqtt_uplink_converter.py
+++ b/thingsboard_gateway/connectors/mqtt/json_mqtt_uplink_converter.py
@@ -19,7 +19,7 @@ from simplejson import dumps
 
 from thingsboard_gateway.connectors.mqtt.mqtt_uplink_converter import MqttUplinkConverter
 from thingsboard_gateway.gateway.constants import REPORT_STRATEGY_PARAMETER, \
-    RECEIVED_TS_PARAMETER, CONVERTED_TS_PARAMETER
+    RECEIVED_TS_PARAMETER, CONVERTED_TS_PARAMETER, USE_RECEIVED_TS_PARAMETER
 from thingsboard_gateway.gateway.entities.attributes import Attributes
 from thingsboard_gateway.gateway.entities.converted_data import ConvertedData
 from thingsboard_gateway.gateway.entities.report_strategy_config import ReportStrategyConfig
@@ -76,7 +76,11 @@ class JsonMqttUplinkConverter(MqttUplinkConverter):
 
         try:
             for datatype in datatypes:
-                timestamp = data.get("ts", data.get("timestamp")) if datatype == 'timeseries' else None
+                if self.__config.get(USE_RECEIVED_TS_PARAMETER, False) is True:
+                    timestamp = converted_data.metadata["receivedTs"]
+                else:
+                    timestamp = data.get("ts", data.get("timestamp")) if datatype == 'timeseries' else None
+
                 for datatype_config in self.__config.get(datatype, []):
                     if isinstance(datatype_config, str) and datatype_config == "*":
                         if datatype == "attributes":

--- a/thingsboard_gateway/connectors/mqtt/json_mqtt_uplink_converter.py
+++ b/thingsboard_gateway/connectors/mqtt/json_mqtt_uplink_converter.py
@@ -19,7 +19,7 @@ from simplejson import dumps
 
 from thingsboard_gateway.connectors.mqtt.mqtt_uplink_converter import MqttUplinkConverter
 from thingsboard_gateway.gateway.constants import REPORT_STRATEGY_PARAMETER, \
-    RECEIVED_TS_PARAMETER, CONVERTED_TS_PARAMETER, USE_RECEIVED_TS_PARAMETER
+    RECEIVED_TS_PARAMETER, CONVERTED_TS_PARAMETER
 from thingsboard_gateway.gateway.entities.attributes import Attributes
 from thingsboard_gateway.gateway.entities.converted_data import ConvertedData
 from thingsboard_gateway.gateway.entities.report_strategy_config import ReportStrategyConfig
@@ -27,6 +27,9 @@ from thingsboard_gateway.gateway.entities.telemetry_entry import TelemetryEntry
 from thingsboard_gateway.gateway.statistics.decorators import CollectStatistics
 from thingsboard_gateway.tb_utility.tb_utility import TBUtility
 from thingsboard_gateway.gateway.statistics.statistics_service import StatisticsService
+
+
+USE_RECEIVED_TS_PARAMETER = "useReceivedTs"
 
 
 class JsonMqttUplinkConverter(MqttUplinkConverter):

--- a/thingsboard_gateway/gateway/constants.py
+++ b/thingsboard_gateway/gateway/constants.py
@@ -61,7 +61,6 @@ RECEIVED_TS_PARAMETER = "receivedTs"
 CONVERTED_TS_PARAMETER = "convertedTs"
 SEND_TO_STORAGE_TS_PARAMETER = "sendToStorageTs"
 DATA_RETRIEVING_STARTED = "dataRetrieveStartedTs"
-USE_RECEIVED_TS_PARAMETER = "useReceivedTs"
 
 # Size of metadata that will be added to messages in debug mode
 # Connector name length should be added to the size of the metadata

--- a/thingsboard_gateway/gateway/constants.py
+++ b/thingsboard_gateway/gateway/constants.py
@@ -61,6 +61,7 @@ RECEIVED_TS_PARAMETER = "receivedTs"
 CONVERTED_TS_PARAMETER = "convertedTs"
 SEND_TO_STORAGE_TS_PARAMETER = "sendToStorageTs"
 DATA_RETRIEVING_STARTED = "dataRetrieveStartedTs"
+USE_RECEIVED_TS_PARAMETER = "useReceivedTs"
 
 # Size of metadata that will be added to messages in debug mode
 # Connector name length should be added to the size of the metadata


### PR DESCRIPTION
# Add option to use received timestamp for all timeseries in MQTT Connector

## Description
Added a new configuration parameter `useReceivedTs` that allows using the same received timestamp for all timeseries data points within a single message. This helps maintain consistency in timestamp values across related measurements that are received together.

The constant `USE_RECEIVED_TS_PARAMETER = "useReceivedTs"` was added to support this feature.

## Changes
- Added new constant `USE_RECEIVED_TS_PARAMETER = "useReceivedTs"` in constants.py
- When enabled, the received timestamp will be used for all timeseries data points in a message instead of individual timestamps
- This helps maintain time consistency across related measurements received in a single message

## Benefits
- Ensures all related measurements within a message have the same timestamp
- Prevents time skew between measurements that logically occurred together
- Makes it easier to correlate related datapoints in time-series analysis
- Provides more accurate representation of when data was actually received

The changes are backwards compatible since the `useReceivedTs` parameter is optional.
