### PR TITLE
Added address pattern support for BACnet

### DIFF
--- a/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
+++ b/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
@@ -155,6 +155,10 @@ class AsyncBACnetConnector(Thread, Connector):
                 DeviceObjectConfig.update_address_in_config_util(device_config)
 
                 who_is_address = Device.get_who_is_address(device_config['address'])
+                if who_is_address is None:
+                    self.__log.error('Invalid address %s', device_config['address'])
+                    continue
+
                 result = await self.__application.do_who_is(device_address=who_is_address)
                 self.__log.debug('WhoIs request sent to device %s', device_config['address'])
 

--- a/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
+++ b/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
@@ -153,7 +153,9 @@ class AsyncBACnetConnector(Thread, Connector):
         for device_config in self.__config.get('devices', []):
             try:
                 DeviceObjectConfig.update_address_in_config_util(device_config)
-                result = await self.__application.do_who_is(device_address=device_config['address'])
+
+                who_is_address = Device.get_who_is_address(device_config['address'])
+                result = await self.__application.do_who_is(device_address=who_is_address)
                 self.__log.debug('WhoIs request sent to device %s', device_config['address'])
 
                 if result is None:

--- a/thingsboard_gateway/connectors/bacnet/device.py
+++ b/thingsboard_gateway/connectors/bacnet/device.py
@@ -12,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from re import escape, match
+from re import escape, match, fullmatch
 import time
 from threading import Thread
 
@@ -124,9 +124,36 @@ class Device(Thread):
     @staticmethod
     def get_who_is_address(address):
         if Device.is_pattern_address(address):
-            return '255.255.255.255'
+            return Device.__get_broadcast_address(address)
         else:
             return address
+
+    @staticmethod
+    def __get_broadcast_address(address):
+        parts = address.split(":")
+
+        if len(parts) == 3:
+            network = parts[0]
+            return Device.__match_network(network)
+
+        elif len(parts) == 2:
+            if fullmatch(r"[0-9X]+", parts[0]):
+                network = parts[0]
+                return Device.__match_network(network)
+            else:
+                return "255.255.255.255"
+
+        elif len(parts) == 1:
+            return "255.255.255.255"
+
+        return None
+
+    @staticmethod
+    def __match_network(network: str):
+        if fullmatch(r"X+", network):
+            return "*:*"
+        else:
+            return f"{network}:*"
 
     @staticmethod
     def is_pattern_address(address):


### PR DESCRIPTION
Device address support the following formats:
Local:
- 192.168.1.160:65340
- 192.XXX.1.160:65340
- 192.168.X.160:65340
- 192.168.X.XXX:65340
- 192.XXX.1.160
Local Broadcast to `255.255.255.255`

Remote:
- 11:10.20.XX.30
- 11:10.20.XX.30:65340

Remote Broadcast to `11:*`

Global:
- X:10.20.30.40:65340
- - X:10.20.30.40

Global Broadcast to `*:*`