### PR TITLE
Add ability to use router vars for BACnet devices connected through router

### DIFF
--- a/thingsboard_gateway/connectors/bacnet/device.py
+++ b/thingsboard_gateway/connectors/bacnet/device.py
@@ -34,9 +34,15 @@ class Device:
     ALLOWED_LOCAL_ADDRESSES_PATTERN_WITH_CUSTOM_PORT = (
         r'^((:(0:)?)[^:,@]+|[^\d:,@][^:,@]*|[^:,@]+)'
         r'\:{expectedPort}'
-        r'(@[^:,@]+(:\d+)?)?$'  # noqa
+        r'(@[^:,@]+(:\d+)?)?$'
     )
     ANY_LOCAL_ADDRESS_WITH_PORT_PATTERN = compile(r"\*:\d+")
+    ROUTER_INFO_PARAMS = [
+        '${routerName}',
+        '${routerId}',
+        '${routerVendorId}',
+        '${routerAddress}'
+    ]
 
     def __init__(self, connector_type, config, i_am_request, queue, logger: TbLogger):
         self.__connector_type = connector_type
@@ -254,6 +260,16 @@ class Device:
             return True
         if '${objectName}' in config.get('deviceInfo', {}).get('deviceProfileExpression', ''):
             return True
+
+        return False
+
+    @staticmethod
+    def need_to_retrieve_router_info(config):
+        for param in Device.ROUTER_INFO_PARAMS:
+            if param in config.get('deviceInfo', {}).get('deviceNameExpression', ''):
+                return True
+            if param in config.get('deviceInfo', {}).get('deviceProfileExpression', ''):
+                return True
 
         return False
 

--- a/thingsboard_gateway/connectors/bacnet/entities/bacnet_device_details.py
+++ b/thingsboard_gateway/connectors/bacnet/entities/bacnet_device_details.py
@@ -28,6 +28,11 @@ class BACnetDeviceDetails:
         self.__max_apdu_length = i_am_request.maxAPDULengthAccepted
         self.__segmentation = i_am_request.segmentationSupported
 
+        self.__router_id = i_am_request.routerId if hasattr(i_am_request, 'routerId') else None
+        self.__router_name = i_am_request.routerName if hasattr(i_am_request, 'routerName') else None
+        self.__router_address = i_am_request.routerAddress if hasattr(i_am_request, 'routerAddress') else None
+        self.__router_vendor_id = i_am_request.routerVendorId if hasattr(i_am_request, 'routerVendorId') else None
+
     def __str__(self):
         return (f"DeviceDetails(address={self.address}, objectIdentifier={self.__object_identifier}, "
                 f"vendorId={self.__vendor_id}, objectName={self.__object_name}")
@@ -54,7 +59,11 @@ class BACnetDeviceDetails:
             "address": self.address,
             "objectId": self.__object_identifier,
             "vendorId": self.__vendor_id,
-            "objectName": self.__object_name
+            "objectName": self.__object_name,
+            "routerId": self.__router_id,
+            "routerName": self.__router_name,
+            "routerAddress": self.__router_address,
+            "routerVendorId": self.__router_vendor_id,
         }
 
     def is_segmentation_supported(self):


### PR DESCRIPTION
Added additional variables for BACnet device connected through router:
- routerId
- routerName
- routerAddress
- routerVendorId

Configuration example:
```json
"deviceNameExpression": "BACnet Device ${routerId} ${routerName} ${routerVendorId} ${routerAddress} ${objectName} ${objectId}"
```

Created device:
<img width="653" alt="image" src="https://github.com/user-attachments/assets/ac0da436-8cd1-4d8c-b2b7-a966a901f353" />
