### PR TITLE
features for BACnet connector, REST connector, Request connector

### DIFF
--- a/thingsboard_gateway/config/bacnet.json
+++ b/thingsboard_gateway/config/bacnet.json
@@ -13,6 +13,10 @@
     "networkNumberQuality": "configured",
     "devicesDiscoverPeriodSeconds": 30
   },
+  "foreignDevice": {
+    "address": "0.0.0.0",
+    "ttl": 900
+  },
   "devices": [
     {
       "deviceInfo": {

--- a/thingsboard_gateway/config/rest.json
+++ b/thingsboard_gateway/config/rest.json
@@ -169,6 +169,25 @@
         "attributeFilter": ".*",
         "requestUrlExpression": "http://127.0.0.1:5001/",
         "valueExpression": "{\"deviceName\":\"${deviceName}\",\"${attributeKey}\":\"${attributeValue}\"}"
+      },
+      {
+        "HTTPMethod": "POST",
+        "SSLVerify": false,
+        "httpHeaders": {
+          "CONTENT-TYPE": "application/json"
+        },
+        "security": {
+          "type": "cert",
+          "cert": "/thingsboard_gateway/config/cert.pem",
+          "key": "/thingsboard_gateway/config/key.pem"
+        },
+        "timeout": 0.5,
+        "tries": 3,
+        "allowRedirects": true,
+        "deviceNameFilter": "CERT.*",
+        "attributeFilter": ".*",
+        "requestUrlExpression": "http://127.0.0.1:5002/",
+        "valueExpression": "{\"deviceName\":\"${deviceName}\",\"${attributeKey}\":\"${attributeValue}\"}"
       }
     ],
     "serverSideRpc": [

--- a/thingsboard_gateway/connectors/bacnet/foreign_application.py
+++ b/thingsboard_gateway/connectors/bacnet/foreign_application.py
@@ -1,0 +1,28 @@
+#     Copyright 2025. ThingsBoard
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from bacpypes3.ipv4.app import ForeignApplication as App
+from bacpypes3.pdu import IPv4Address
+
+from thingsboard_gateway.connectors.bacnet.application import Application
+from thingsboard_gateway.connectors.bacnet.entities.device_object_config import DeviceObjectConfig
+
+
+class ForeignApplication(Application, App):
+    def __init__(self, device_object_config: DeviceObjectConfig, indication_callback, logger):
+        super().__init__(device_object_config, indication_callback, logger)
+
+    def register_foreign_device(self, address: IPv4Address, ttl: int) -> None:
+        self.__log.debug(f"(register_foreign_device) Registering foreign device")
+        self.register(address, ttl)

--- a/thingsboard_gateway/connectors/request/request_connector.py
+++ b/thingsboard_gateway/connectors/request/request_connector.py
@@ -261,10 +261,17 @@ class RequestConnector(Connector, Thread):
                 logger.error("Converter for request to '%s' endpoint is not defined. Request will be skipped.", request["config"].get("url"))
                 return
             request_url_from_config = request["config"]["url"]
-            request_url_from_config = str('/' + request_url_from_config) if request_url_from_config[
-                                                                                0] != '/' else request_url_from_config
+            request_url_from_config = (
+                str("/" + request_url_from_config)
+                if not request_url_from_config.startswith("/")
+                   and not request_url_from_config.startswith("http")
+                else request_url_from_config
+            )
             logger.debug("Obtained request url from config - %s ", request_url_from_config)
-            url = self.__host + request_url_from_config
+            if not request_url_from_config.startswith("http"):
+                url = self.__host + request_url_from_config
+            else:
+                url = request_url_from_config
             request_timeout = request["config"].get("timeout", 1)
             params = {
                 "method": request["config"].get("httpMethod", "GET"),

--- a/thingsboard_gateway/connectors/rest/rest_connector.py
+++ b/thingsboard_gateway/connectors/rest/rest_connector.py
@@ -499,21 +499,24 @@ class BaseDataHandler:
 
     @staticmethod
     async def _convert_data_from_request(request):
-        if request.method == 'GET':
-            params = request.query
+        result = dict(request.match_info)
+        result.update(dict(request.query))
 
-            return dict(params)
-        else:
+        if request.method != "GET":
             try:
                 json_data = await request.json()
+                if isinstance(json_data, list):
+                    json_data = json_data[0]
             except json.decoder.JSONDecodeError:
                 data = await request.post()
                 if len(data):
                     json_data = dict(data)
                 else:
-                    json_data = await request.text()
+                    json_data = {"text": await request.text()}
 
-            return json_data
+            result.update(json_data)
+
+        return result
 
     @staticmethod
     def modify_data_for_remote_response(data, modify):

--- a/thingsboard_gateway/connectors/rest/rest_connector.py
+++ b/thingsboard_gateway/connectors/rest/rest_connector.py
@@ -400,6 +400,13 @@ class RESTConnector(Connector, Thread):
                 security = HTTPBasicAuthRequest(request_dict["config"]["security"]["username"],
                                                 request_dict["config"]["security"]["password"])
 
+            cert = None
+            if request_dict["config"].get('security', {}).get('type', 'anonymous').lower() == "cert":
+                if request_dict["config"]["security"].get('key', ''):
+                    cert = (request_dict["config"]["security"]["cert"], request_dict["config"]["security"]["key"])
+                else:
+                    cert = request_dict["config"]["security"]["cert"]
+
             request_timeout = request_dict["config"].get("timeout")
 
             data = {"data": request_dict["config"]["data"]}
@@ -410,6 +417,7 @@ class RESTConnector(Connector, Thread):
                 "allow_redirects": request_dict["config"].get("allowRedirects", False),
                 "verify": request_dict["config"].get("SSLVerify"),
                 "auth": security,
+                "cert": cert,
                 **data,
             }
             logger.debug(url)


### PR DESCRIPTION
With commit https://github.com/thingsboard/thingsboard-gateway/pull/1856/commits/9fe25156f21cb09a9147fe6024c393ddd63a6910 it is possible to register foreign device to support remote BACnet networks.

If `foreignDevice.address` is defined in config and not an empty string the functionality is activated.

```json
{
  "foreignDevice": {
    "address": "0.0.0.0",
    "ttl": 900
  },
}
```