### PR TITLE
Fix for constant device profile expression parsing failure in MQTT

### DIFF
--- a/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
+++ b/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
@@ -601,7 +601,7 @@ class MqttConnector(Connector, Thread):
             found_device_type = TBUtility.get_value(device_info["deviceProfileExpression"], content,
                                                     expression_instead_none=True)
         elif device_info.get("deviceProfileExpressionSource") == 'constant':
-            found_device_type = TBUtility.get_value(device_info["deviceProfileExpression"], content,)
+            found_device_type = device_info["deviceProfileExpression"]
 
         return found_device_name, found_device_type
 


### PR DESCRIPTION
Fix: ThingsBoard uses default value when device profile is set to a custom constant