### PR TITLE
Added max file size config for log handlers

### DIFF
--- a/tests/integration/data/gateway/logs.json
+++ b/tests/integration/data/gateway/logs.json
@@ -29,6 +29,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "connectorHandler": {
@@ -38,6 +39,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "converterHandler": {
@@ -47,6 +49,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "tb_connectionHandler": {
@@ -56,6 +59,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "storageHandler": {
@@ -65,6 +69,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "extensionHandler": {
@@ -74,6 +79,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     }
   },

--- a/thingsboard_gateway/config/logs.json
+++ b/thingsboard_gateway/config/logs.json
@@ -29,6 +29,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "connectorHandler": {
@@ -38,6 +39,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "converterHandler": {
@@ -47,6 +49,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "tb_connectionHandler": {
@@ -56,6 +59,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "storageHandler": {
@@ -65,6 +69,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     },
     "extensionHandler": {
@@ -74,6 +79,7 @@
       "backupCount": 7,
       "interval": 3,
       "when": "D",
+      "maxBytes": 0,
       "encoding": "utf-8"
     }
   },


### PR DESCRIPTION
This PR adds functionality to rotate log files by configured max file size in bytes.

Implementation is inspired by https://github.com/suraj-arya/chandler & https://github.com/python/cpython/blob/3.14/Lib/logging/handlers.py

Closes https://github.com/thingsboard/thingsboard-gateway/issues/1867