### PR TITLE
Added data unpack functionality in Request connector

### DIFF
--- a/thingsboard_gateway/config/request.json
+++ b/thingsboard_gateway/config/request.json
@@ -20,6 +20,7 @@
       "allowRedirects": true,
       "timeout": 0.5,
       "scanPeriod": 5,
+      "dataUnpackExpression": "",
       "converter": {
         "type": "json",
         "deviceNameJsonExpression": "SD8500",
@@ -54,6 +55,7 @@
       "allowRedirects": true,
       "timeout": 0.5,
       "scanPeriod": 100,
+      "dataUnpackExpression": "",
       "converter": {
         "type": "custom",
         "deviceNameJsonExpression": "SD8500",

--- a/thingsboard_gateway/connectors/request/request_connector.py
+++ b/thingsboard_gateway/connectors/request/request_connector.py
@@ -308,7 +308,7 @@ class RequestConnector(Connector, Thread):
                         # }
                         data_unpack_expression = request["config"].get("dataUnpackExpression")
                         if data_unpack_expression:
-                            json_response = TBUtility.get_values(data_unpack_expression, json_response, expression_instead_none=True)
+                            json_response = TBUtility.get_value(data_unpack_expression, json_response)
 
                         config_converter_data.append(json_response)
                     except UnicodeDecodeError:

--- a/thingsboard_gateway/connectors/request/request_connector.py
+++ b/thingsboard_gateway/connectors/request/request_connector.py
@@ -308,7 +308,7 @@ class RequestConnector(Connector, Thread):
                         # }
                         data_unpack_expression = request["config"].get("dataUnpackExpression")
                         if data_unpack_expression:
-                            json_response = TBUtility.get_value(data_unpack_expression, json_response)
+                            json_response = TBUtility.get_value(data_unpack_expression, json_response, value_type="json")
 
                         config_converter_data.append(json_response)
                     except UnicodeDecodeError:

--- a/thingsboard_gateway/connectors/request/request_connector.py
+++ b/thingsboard_gateway/connectors/request/request_connector.py
@@ -299,7 +299,18 @@ class RequestConnector(Connector, Thread):
                 if not converter_queue.full():
                     config_converter_data = [url, request["converter"]]
                     try:
-                        config_converter_data.append(response.json())
+                        json_response = response.json()
+
+                        # Unpack data if dataUnpackExpression is defined in config
+                        # This allows to unpack JSON responses that have final data at a sub key on any level
+                        # {
+                        #   "device": [...]
+                        # }
+                        data_unpack_expression = request["config"].get("dataUnpackExpression")
+                        if data_unpack_expression:
+                            json_response = TBUtility.get_values(data_unpack_expression, json_response, expression_instead_none=True)
+
+                        config_converter_data.append(json_response)
                     except UnicodeDecodeError:
                         config_converter_data.append(response.content)
                     except JSONDecodeError:


### PR DESCRIPTION
Unpack data if `dataUnpackKey` is defined in config
```json
{
  "mapping": [
    {
      "dataUnpackKey": "device"
    }
  ]
}
```

This allows to unpack JSON responses that have final data at a sub key
```json
{
   "device": [...]
}
```