### PR TITLE
Added support for sub requests in Request connector

### DIFF
--- a/thingsboard_gateway/config/request.json
+++ b/thingsboard_gateway/config/request.json
@@ -133,16 +133,16 @@
       "allowRedirects": true,
       "timeout": 3.0,
       "scanPeriod": 1800,
+      "subRequests": {
+        "cumPwr": {
+          "url": "/${id}/hist/values/ActiveEnergy/SUM13/3600?start=RELATIVE_-1HOUR&end=RELATIVE_-1HOUR&online=false&aggregate=false",
+          "processingFunction": "def process_data(data, key): return {key: float(data[\"values\"][0][\"avg\"])/1000.0}"
+        }
+      },
       "converter": {
         "type": "json",
         "deviceNameJsonExpression": "${id}-${type}",
         "deviceTypeJsonExpression": "GridVis",
-        "subRequests": {
-          "cumPwr": {
-            "url": "/${id}/hist/values/ActiveEnergy/SUM13/3600?start=RELATIVE_-1HOUR&end=RELATIVE_-1HOUR&online=false&aggregate=false",
-            "processingFunction": "def process_data(data, key): return {key: float(data[\"values\"][0][\"avg\"])/1000.0}"
-          }
-        },
         "attributes": [
           {
             "key": "id",


### PR DESCRIPTION
This feature adds the possibility to do sub requests based on the data retrieved by an initial request.

As example, the initial request offers `id` key where we want to do a sub request to another URL that needs the `id` from the initial request.

### intial request
URL: http://xyz/devices

Response:
```json
{
  "id": 1,
  "name": "Test"
}
```

### sub request
URL: http://xyz/devices/${id}/status

Response:
```json
{
  "status": "OK"
}
```

This gives the possibility to implement dynamic device data gathering based on the response of the initial request.

In combination with https://github.com/thingsboard/thingsboard-gateway/pull/1874 the initial response could also give a list of devices on a sub key that are sub-sequentially requested like described above.

The data retrieved by the sub request is merged with the data of the initial request.
It is also possible to define a processing function for the data retrieved by the sub request. This function can be used to manipulate the retrieved data before the merge is done.