### PR TITLE
Added support for proprietary devices in BACnet connector

### DIFF
--- a/thingsboard_gateway/connectors/bacnet/application.py
+++ b/thingsboard_gateway/connectors/bacnet/application.py
@@ -237,7 +237,7 @@ class Application(NormalApplication, ForeignApplication):
                 object_id = object['objectId']
                 if not isinstance(object_id, ObjectIdentifier):
                     obj_str = f"{object['objectType']},{object_id}"
-                    object_id = ObjectIdentifier(obj_str)
+                    object_id = vendor_info.object_identifier(obj_str)
 
                 object_class = vendor_info.get_object_class(object_id[0])
                 if object_class is None:
@@ -249,7 +249,7 @@ class Application(NormalApplication, ForeignApplication):
                     object['propertyId'] = {object['propertyId']}
 
                 for prop in object['propertyId']:
-                    property_identifier = PropertyIdentifier(prop)
+                    property_identifier = vendor_info.property_identifier(prop)
 
                     properties.append(property_identifier)
 


### PR DESCRIPTION
This feature makes it possible to inject proprietary device information the way BACpypes3 handels it.

To inject devices it is needed to import a custom class, atm this is only possible for advanced users since it is needed to implement a custom `AsyncBACnetConnector` class.

This PR makes sure the actual BACnet connector implementation is able to handle it.