### PR TITLE
Fixed data key filtering in BACnet connector uplink converter

### DIFF
--- a/thingsboard_gateway/connectors/bacnet/bacnet_uplink_converter.py
+++ b/thingsboard_gateway/connectors/bacnet/bacnet_uplink_converter.py
@@ -139,8 +139,9 @@ class AsyncBACnetUplinkConverter(AsyncBACnetConverter):
 
         for value_item in data:
             key_camel_case = TBUtility.kebab_case_to_camel_case(value_item['propName'])
-            if key_camel_case in key_expression:
-                key_expression = key_expression.replace('${' + key_camel_case + '}', str(value_item['value']))
+            find_string = '${' + key_camel_case + '}'
+            if find_string in key_expression:
+                key_expression = key_expression.replace(find_string, str(value_item['value']))
             else:
                 unused_keys.append(value_item)
 


### PR DESCRIPTION
This PR fixes a problem with filtering of data point used for replacements in key expressions.

Before this change following config would lead to missing data points:
```json
{
  "devices": [
    {
      "attributes": [
        {
          "key": "description",
          "objectType": "device",
          "objectId": "2098183",
          "propertyId": "description"
        }
      ]
    }
  ]
}
```

After this change only correctly defined expression are respected to replace:
```json
{
  "devices": [
    {
      "attributes": [
        {
          "key": "${description}",
          "objectType": "device",
          "objectId": "2098183",
          "propertyId": "description"
        }
      ]
    }
  ]
}
```