### PR TITLE
fix logic for parsing arguments with different delimiter

### DIFF
--- a/tests/unit/connectors/opcua/test_server_side_rpc.py
+++ b/tests/unit/connectors/opcua/test_server_side_rpc.py
@@ -355,7 +355,7 @@ class TestOpcUaReservedServerSideRpc(OpcUABaseTest):
 
         done_future, create_task_mock, results = self.call_reserved_with_result(rpc_request, result)
 
-        self.assertEqual(rpc_request.params, 'ns=2;i=13;')
+        self.assertEqual(rpc_request.params, 'ns=2;i=13')
         create_task_mock.assert_called_once()
         self.assertEqual(results, result)
         self.assert_gateway_reply(rpc_request, result)
@@ -371,7 +371,7 @@ class TestOpcUaReservedServerSideRpc(OpcUABaseTest):
 
         done_future, create_task_mock, results = self.call_reserved_with_result(rpc_request, result)
 
-        self.assertEqual(rpc_request.params, 'ns=200;i=136;')
+        self.assertEqual(rpc_request.params, 'ns=200;i=136')
         create_task_mock.assert_called_once()
         self.assertEqual(results, result)
         self.assert_gateway_reply(rpc_request, result)

--- a/thingsboard_gateway/connectors/opcua/entities/rpc_request.py
+++ b/thingsboard_gateway/connectors/opcua/entities/rpc_request.py
@@ -110,12 +110,12 @@ class OpcUaRpcRequest:
     def _fill_reserved_rpc_request(self, content: dict):
         params = content.get(DATA_PARAMETER, {}).get(RPC_PARAMS_PARAMETER)
         if self.rpc_method == "get":
-            self.params = params
+            self.params = self.params.rstrip(' ;\t\n\r')
             return
         if self.rpc_method != "set" or not isinstance(params, str):
             return
-
         ident = self.__find_identifier_request(params)
+
         if ident:
             value = params[len(ident):]
             delimiter = next((p for p in RPC_SET_SPLIT_PATTERNS if p in params), None)
@@ -144,6 +144,7 @@ class OpcUaRpcRequest:
 
     @staticmethod
     def __find_identifier_request(path: str) -> list | None:
-        identifier = findall(r"(ns=\d+;[isgb]=[^}\s]+)(?=\s|$)", path)
+        identifier = findall(r"(ns=\d+;[isgb]=[^;\s}]+)(?=;|\s|$)", path)
         if identifier:
             return identifier[0]
+


### PR DESCRIPTION
fixed logic for parsing resevred rpc methods with different delimiters