### PR TITLE
fix missing JSON dump for single-attribute request

### DIFF
--- a/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
+++ b/thingsboard_gateway/connectors/mqtt/mqtt_connector.py
@@ -24,7 +24,6 @@ from typing import List, Union
 
 import orjson
 from orjson.orjson import JSONDecodeError
-from simplejson import dumps
 
 from thingsboard_gateway.connectors.mqtt.backward_compatibility_adapter import BackwardCompatibilityAdapter
 from thingsboard_gateway.gateway.constant_enums import Status
@@ -807,7 +806,7 @@ class MqttConnector(Connector, Thread):
 
             if len(attribute_name) <= 1:
                 data = value_expression.replace("${attributeKey}", str(attribute_name[0])) \
-                    .replace("${attributeValue}", dumps(attribute_values))
+                    .replace("${attributeValue}", orjson.dumps(attribute_values).decode('utf-8'))
             else:
                 data = orjson.dumps(attribute_values)
                 self.__log.debug("Attribute data: %s for device %s to topic: %s", data, device_name, topic)


### PR DESCRIPTION
1. Fix missing JSON serialization when requesting a single attribute name.