### PR TITLE
feat(opcua): support constant datapoints (attributes + one-time telemetry)

### DIFF
--- a/tests/unit/connectors/opcua/data/constants/opcua_config_constants.json
+++ b/tests/unit/connectors/opcua/data/constants/opcua_config_constants.json
@@ -1,0 +1,22 @@
+{
+  "attributes": [
+    { "key": "Customer", "type": "constant", "value": "ACME Corp" },
+    { "key": "Frequency", "type": "path", "value": "${Frequency}" }
+  ],
+  "attributes_updates": [],
+  "deviceInfo": {
+    "deviceNameExpression": "OPCUA New Advanced Device",
+    "deviceNameExpressionSource": "path",
+    "deviceProfileExpression": "default",
+    "deviceProfileExpressionSource": "constant"
+  },
+  "deviceNodePattern": "Root\\.Objects\\.MyObject",
+  "deviceNodeSource": "path",
+  "device_name": "OPCUA New Advanced Device",
+  "device_type": "default",
+  "rpc_methods": [],
+  "timeseries": [
+    { "key": "InitialBatchSize", "type": "constant", "value": "12" },
+    { "key": "Temperature", "type": "path", "value": "${Temperature}" }
+  ]
+}

--- a/tests/unit/connectors/opcua/test_constants.py
+++ b/tests/unit/connectors/opcua/test_constants.py
@@ -1,0 +1,84 @@
+#     Copyright 2025. ThingsBoard
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from tests.unit.connectors.opcua.opcua_base_test import OpcUABaseTest
+
+
+class OpcUAConstantsTest(OpcUABaseTest):
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        # Prepare connector fields used by __send_constants_for_device
+        self.connector._OpcUaConnector__constant_telemetry_sent_devices = set()
+        # Avoid touching Thread.name setter; patch accessors instead
+        self.connector.get_name = lambda: "test-connector"
+        self.connector.get_id = lambda: "test-id"
+
+        # Build device from constants config
+        self.fake_device = self.create_fake_device('constants/opcua_config_constants.json')
+        self.connector._OpcUaConnector__device_nodes[:] = [self.fake_device]
+
+    async def asyncTearDown(self):
+        await super().asyncTearDown()
+
+    async def test_parse_constants_buckets(self):
+        # Device should have parsed constants into dedicated buckets
+        self.assertTrue(hasattr(self.fake_device, "constant_attributes"))
+        self.assertTrue(hasattr(self.fake_device, "constant_timeseries"))
+
+        self.assertEqual(len(self.fake_device.constant_attributes), 1, "Expected one constant attribute")
+        self.assertEqual(self.fake_device.constant_attributes[0]["key"], "Customer")
+        self.assertEqual(self.fake_device.constant_attributes[0]["value"], "ACME Corp")
+
+        self.assertEqual(len(self.fake_device.constant_timeseries), 1, "Expected one constant timeseries")
+        self.assertEqual(self.fake_device.constant_timeseries[0]["key"], "InitialBatchSize")
+        self.assertEqual(self.fake_device.constant_timeseries[0]["value"], "12")
+
+    async def test_send_constants_once_and_idempotent(self):
+        # First send: attributes + telemetry (one-time)
+        self.connector._OpcUaConnector__send_constants_for_device(self.fake_device)
+
+        calls = self.connector._OpcUaConnector__gateway.send_to_storage.call_args_list
+        self.assertEqual(len(calls), 1, "Expected 1 send_to_storage call on first dispatch")
+
+        first_data = calls[0][0][2]  # args: (connector_name, connector_id, converted_data)
+        first_payload = first_data.to_dict()
+
+        # Attributes include the constant "Customer"
+        self.assertIn("attributes", first_payload)
+        self.assertEqual(first_payload["attributes"].get("Customer"), "ACME Corp")
+
+        # Telemetry includes one-time constant "InitialBatchSize" cast to integer
+        self.assertIn("telemetry", first_payload)
+        self.assertEqual(len(first_payload["telemetry"]), 1, "Expected one telemetry entry")
+        first_telemetry_entry = first_payload["telemetry"][0]
+        self.assertIn("values", first_telemetry_entry)
+        self.assertIsInstance(first_telemetry_entry.get("ts"), int, "Telemetry ts must be an integer timestamp")
+        self.assertEqual(first_telemetry_entry["values"].get("InitialBatchSize"), 12, "Expected int-casted value 12")
+
+        # Second send: attributes again, telemetry should NOT be re-sent
+        self.connector._OpcUaConnector__send_constants_for_device(self.fake_device)
+
+        calls = self.connector._OpcUaConnector__gateway.send_to_storage.call_args_list
+        self.assertEqual(len(calls), 2, "Expected 2 send_to_storage calls after second dispatch")
+
+        second_data = calls[1][0][2]
+        second_payload = second_data.to_dict()
+
+        # Attributes should still contain the constant "Customer"
+        self.assertEqual(second_payload["attributes"].get("Customer"), "ACME Corp")
+
+        # Telemetry should be empty (one-time semantics)
+        self.assertIsInstance(second_payload.get("telemetry"), list)
+        self.assertEqual(len(second_payload["telemetry"]), 0, "Constant telemetry must be sent only once")

--- a/thingsboard_gateway/connectors/opcua/opcua_connector.py
+++ b/thingsboard_gateway/connectors/opcua/opcua_connector.py
@@ -30,6 +30,7 @@ from thingsboard_gateway.connectors.connector import Connector
 from thingsboard_gateway.gateway.constants import CONNECTOR_PARAMETER, RECEIVED_TS_PARAMETER, CONVERTED_TS_PARAMETER, \
     DATA_RETRIEVING_STARTED, REPORT_STRATEGY_PARAMETER, ON_ATTRIBUTE_UPDATE_DEFAULT_TIMEOUT
 from thingsboard_gateway.gateway.entities.converted_data import ConvertedData
+from thingsboard_gateway.gateway.entities.telemetry_entry import TelemetryEntry
 from thingsboard_gateway.gateway.entities.report_strategy_config import ReportStrategyConfig
 from thingsboard_gateway.gateway.statistics.statistics_service import StatisticsService
 from thingsboard_gateway.gateway.tb_gateway_service import TBGatewayService
@@ -176,6 +177,7 @@ class OpcUaConnector(Connector, Thread):
 
         self.__device_nodes: List[Device] = []
         self.__nodes_config_cache: Dict[NodeId, List[Device]] = {}
+        self.__constant_telemetry_sent_devices = set()
         self.__next_poll = 0
         self.__next_scan = 0
         self.__client_recreation_required = True
@@ -823,16 +825,16 @@ class OpcUaConnector(Connector, Thread):
 
                         device_config = {**device_config, 'device_name': device_name, 'device_type': device_profile}
                         device_path = [node_path_node_object['path'] for node_path_node_object in node]
-                        self.__device_nodes.append(
-                            Device(path=device_path, name=device_name, device_profile=device_profile,
-                                   config=device_config,
-                                   converter=converter(
-                                       device_config, self.__converter_log),
-                                   converter_for_sub=converter(device_config,
-                                                               self.__converter_log) if self.__enable_subscriptions else None,
-                                   device_node=node[-1]['node'],
-                                   logger=self.__log))
+                        new_device = Device(path=device_path, name=device_name, device_profile=device_profile,
+                                            config=device_config,
+                                            converter=converter(device_config, self.__converter_log),
+                                            converter_for_sub=converter(device_config, self.__converter_log) if self.__enable_subscriptions else None,
+                                            device_node=node[-1]['node'],
+                                            logger=self.__log)
+                        self.__device_nodes.append(new_device)
                         self.__log.info('Added device node: %s', device_name)
+                        # Send constant attributes always on creation; constant telemetry only once per process
+                        self.__send_constants_for_device(new_device)
         self.__log.debug('Device nodes: %s', self.__device_nodes)
 
     async def _load_devices_nodes(self):
@@ -1097,6 +1099,49 @@ class OpcUaConnector(Connector, Thread):
         self.__gateway.send_to_storage(self.get_name(), self.get_id(), data)
         self.statistics['MessagesSent'] = self.statistics['MessagesSent'] + 1
         self.__log.debug('Count data msg to storage: %s', self.statistics['MessagesSent'])
+
+    def __send_constants_for_device(self, device: Device):
+        """
+        Send constant attributes on every device creation and reconnection (because devices are recreated),
+        and constant telemetry only once per process lifetime for a given device.
+        """
+        try:
+            has_attributes = False
+            has_telemetry = False
+            converted_data = ConvertedData(device_name=device.name, device_type=device.device_profile)
+
+            # Constant attributes
+            for entry in getattr(device, 'constant_attributes', []):
+                key = entry.get('key')
+                value = entry.get('value')
+                casted_value = self.__guess_type_and_cast(value)
+                dp_key = TBUtility.convert_key_to_datapoint_key(key, device.report_strategy or None, entry, self.__log)
+                converted_data.add_to_attributes({dp_key: casted_value})
+                has_attributes = True
+
+            # Constant telemetry (send once per device name per process)
+            if device.name not in self.__constant_telemetry_sent_devices:
+                telemetry_values = {}
+                for entry in getattr(device, 'constant_timeseries', []):
+                    key = entry.get('key')
+                    value = entry.get('value')
+                    casted_value = self.__guess_type_and_cast(value)
+                    dp_key = TBUtility.convert_key_to_datapoint_key(key, device.report_strategy or None, entry, self.__log)
+                    telemetry_values[dp_key] = casted_value
+
+                if telemetry_values:
+                    ts = int(time() * 1000)
+                    telemetry_entry = TelemetryEntry(telemetry_values, ts)
+                    converted_data.add_to_telemetry(telemetry_entry)
+                    has_telemetry = True
+                    self.__constant_telemetry_sent_devices.add(device.name)
+
+            if has_attributes or has_telemetry:
+                self.__gateway.send_to_storage(self.get_name(), self.get_id(), converted_data)
+                self.__log.info("Sent constant data for device %s: attributes=%s, telemetry=%s",
+                                device.name, has_attributes, has_telemetry)
+        except Exception as e:
+            self.__log.exception("Failed to send constant data for device %s: %s", device.name, e)
 
     @staticmethod
     def get_rpc_node_pattern_and_base_path(params, device, logger):


### PR DESCRIPTION
# feat(opcua): support constant datapoints (attributes + one-time telemetry)

## Summary
Adds first-class support for constant datapoints in the OPC-UA connector:
- Attributes with type: "constant" are sent when a device is created and on every reconnection.
- Telemetry with type: "constant" is sent once per device per gateway process (idempotent).
- Values are auto-cast (bool/int/float) when possible; otherwise kept as string.
- Telemetry is timestamped with the gateway time.
- Report strategy is respected at datapoint level via TBUtility.

## Motivation
Previously, OPC-UA mapping handled datapoints backed by NodeId or path expressions but ignored constants. This feature enables:
- Populating device attributes with fixed metadata (e.g., Customer, Location).
- Emitting one-time constant telemetry (e.g., initial setup values) without requiring OPC-UA nodes.

## Implementation Details
- Parsing/modeling on device side:
  - Added in-memory collections (not polled/subscribed from OPC-UA):
    - constant_attributes and constant_timeseries, collected during device config parsing in [`python.Device.load_values()`](thingsboard_gateway/connectors/opcua/device.py:78).
- Sending pipeline on connector:
  - New routine to emit constants: [`python.OpcUaConnector.__send_constants_for_device()`](thingsboard_gateway/connectors/opcua/opcua_connector.py:1103).
  - Invoked right after device creation in [`python.OpcUaConnector._create_new_devices()`](thingsboard_gateway/connectors/opcua/opcua_connector.py:789).
  - Idempotence for constant telemetry via in-memory set created in [`thingsboard_gateway/connectors/opcua/opcua_connector.py`](thingsboard_gateway/connectors/opcua/opcua_connector.py).
  - Key building preserves report strategy: [`python.TBUtility.convert_key_to_datapoint_key()`](thingsboard_gateway/tb_utility/tb_utility.py:244).
  - Auto type inference for constant values: [`python.OpcUaConnector.__guess_type_and_cast()`](thingsboard_gateway/connectors/opcua/opcua_connector.py:1449).
  - Telemetry timestamp uses gateway time by default: [`python.TelemetryEntry.__init__()`](thingsboard_gateway/gateway/entities/telemetry_entry.py:24).

## Behavior
- Attributes (type: "constant")
  - Sent on device creation and every reconnection (devices are recreated on reconnect).
- Telemetry (type: "constant")
  - Sent exactly once per device per process (not re-sent on reconnects).

## Configuration Example (new mapping format)
```json
{
  "mapping": [
    {
      "deviceNodePattern": "Root\\.Objects\\.Device1",
      "deviceInfo": {
        "deviceNameExpressionSource": "path",
        "deviceNameExpression": "Device ${Root\\.Objects\\.Device1\\.serialNumber}",
        "deviceProfileExpressionSource": "constant",
        "deviceProfileExpression": "default"
      },
      "attributes": [
        { "key": "Customer", "type": "constant", "value": "ACME Corp" }
      ],
      "timeseries": [
        { "key": "InitialBatchSize", "type": "constant", "value": "12" }
      ]
    }
  ]
}
```

## Casting Rules
- "true"/"false" (case-insensitive) → boolean
- -123 → integer
- 45.67 → float
- Anything else → string

## Backward Compatibility
- No breaking changes. Existing path/identifier-based datapoints remain unchanged.
- The backward-compatibility adapter continues to set type: "constant" where applicable; the new pipeline now handles those entries.

## Tests / Verification
- Unit tests (added in this PR):
  - [`tests/unit/connectors/opcua/test_constants.py`](tests/unit/connectors/opcua/test_constants.py)
    - Validates parsing buckets for constants and idempotent behavior of one-time constant telemetry.
  - Fixture config:
    - [`tests/unit/connectors/opcua/data/constants/opcua_config_constants.json`](tests/unit/connectors/opcua/data/constants/opcua_config_constants.json)
- Blackbox (optional, requires TB test environment):
  - Example configuration to validate runtime behavior:
    - [`tests/blackbox/data/opcua/configs/uplink_configs/constants_config.json`](tests/blackbox/data/opcua/configs/uplink_configs/constants_config.json)
  - Integrates with existing OPC-UA blackbox harness. Not executed as part of this PR by default.

## Documentation Impact
- Update OPC-UA connector mapping docs to include:
  - Support for type: "constant" in attributes and timeseries.
  - Semantics (attributes on create/reconnect, telemetry one-time).
  - Casting rules and gateway timestamp.
  - Example mapping similar to the snippet above.

## Touched Code
- Device parsing and storage:
  - [`thingsboard_gateway/connectors/opcua/device.py`](thingsboard_gateway/connectors/opcua/device.py)
  - [`python.Device.load_values()`](thingsboard_gateway/connectors/opcua/device.py:78)
- Connector logic:
  - [`python.OpcUaConnector.__send_constants_for_device()`](thingsboard_gateway/connectors/opcua/opcua_connector.py:1103)
  - [`python.OpcUaConnector._create_new_devices()`](thingsboard_gateway/connectors/opcua/opcua_connector.py:789)
  - [`python.OpcUaConnector.__guess_type_and_cast()`](thingsboard_gateway/connectors/opcua/opcua_connector.py:1449)
- Utilities and entities (used as-is):
  - [`python.TBUtility.convert_key_to_datapoint_key()`](thingsboard_gateway/tb_utility/tb_utility.py:244)
  - [`python.TelemetryEntry.__init__()`](thingsboard_gateway/gateway/entities/telemetry_entry.py:24)
- Tests:
  - [`tests/unit/connectors/opcua/test_constants.py`](tests/unit/connectors/opcua/test_constants.py)
  - [`tests/unit/connectors/opcua/data/constants/opcua_config_constants.json`](tests/unit/connectors/opcua/data/constants/opcua_config_constants.json)
  - [`tests/blackbox/data/opcua/configs/uplink_configs/constants_config.json`](tests/blackbox/data/opcua/configs/uplink_configs/constants_config.json)

## Checklist
- [x] Parse/store constant datapoints (no OPC-UA read required)
- [x] Send constant attributes on create/reconnect
- [x] Send constant telemetry once per device per process
- [x] Type inference and gateway timestamp
- [x] Datapoint-level report strategy
- [x] Unit tests
- [ ] Blackbox validation on TB test environment
- [ ] Documentation and CHANGELOG updates