### PR TITLE
Fixed device name expression access in json converter

### DIFF
--- a/thingsboard_gateway/connectors/rest/json_rest_uplink_converter.py
+++ b/thingsboard_gateway/connectors/rest/json_rest_uplink_converter.py
@@ -43,7 +43,7 @@ class JsonRESTUplinkConverter(RESTConverter):
             device_info = self.__config.get("deviceInfo")
             if device_info.get("deviceNameExpression") is not None:
                 if device_info.get("deviceNameExpressionSource") == "constant":
-                    device_name = device_info.deviceNameExpression
+                    device_name = device_info.get("deviceNameExpression")
                 else:
                     device_name_tags = TBUtility.get_values(device_info.get("deviceNameExpression"), data, get_tag=True)
                     device_name_values = TBUtility.get_values(device_info.get("deviceNameExpression"), data,


### PR DESCRIPTION
Use get() method to safely access deviceNameExpression from device_info dictionary to prevent potential AttributeError