### PR TITLE
Added batch reading

### DIFF
--- a/thingsboard_gateway/connectors/modbus/entities/bytes_uplink_converter_config.py
+++ b/thingsboard_gateway/connectors/modbus/entities/bytes_uplink_converter_config.py
@@ -24,6 +24,7 @@ class BytesUplinkConverterConfig:
         self.word_order = Endian.BIG if kwargs.get('wordOrder', 'LITTLE').upper() == "BIG" else Endian.LITTLE
         self.telemetry = kwargs.get('timeseries', [])
         self.attributes = kwargs.get('attributes', [])
+        self.unit_id = kwargs['unitId']
 
     def is_readable(self):
         return len(self.telemetry) > 0 or len(self.attributes) > 0

--- a/thingsboard_gateway/connectors/modbus/slave.py
+++ b/thingsboard_gateway/connectors/modbus/slave.py
@@ -46,6 +46,7 @@ from thingsboard_gateway.connectors.modbus.constants import (
 )
 from thingsboard_gateway.connectors.modbus.entities.bytes_uplink_converter_config import BytesUplinkConverterConfig
 from thingsboard_gateway.connectors.modbus.modbus_converter import ModbusConverter
+from thingsboard_gateway.connectors.modbus.utils import Utils
 from thingsboard_gateway.gateway.constants import (
     DEVICE_NAME_PARAMETER,
     DEVICE_TYPE_PARAMETER,
@@ -251,6 +252,9 @@ class Slave(Thread):
     async def read(self, function_code, address, objects_count):
         self._log.debug('Reading %s registers from address %s with function code %s', objects_count, address,
                         function_code)
+
+        if Utils.is_wide_range_request(address):
+            address, objects_count = Utils.parse_wide_range_request(address, objects_count)
 
         result = await self.__read(function_code, address, objects_count)
 

--- a/thingsboard_gateway/connectors/modbus/utils.py
+++ b/thingsboard_gateway/connectors/modbus/utils.py
@@ -1,0 +1,62 @@
+#     Copyright 2025. ThingsBoard
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from pymodbus import ExceptionResponse
+from pymodbus.exceptions import ModbusIOException
+
+
+class Utils:
+    @staticmethod
+    def is_wide_range_request(address):
+        if not isinstance(address, str):
+            return False
+
+        return '-' in address
+
+    @staticmethod
+    def parse_wide_range_request(address, objects_count=1):
+        try:
+            address_range = address.split('-')
+            registers_to_read = (int(address_range[1]) - int(address_range[0]) + 1) * objects_count
+            return int(address_range[0]), registers_to_read
+        except Exception as e:
+            raise ValueError('Invalid address range: {}'.format(e))
+
+    @staticmethod
+    def get_start_address(address_pattern):
+        if isinstance(address_pattern, int):
+            return address_pattern
+
+        if Utils.is_wide_range_request(address_pattern):
+            return Utils.parse_wide_range_request(address_pattern)[0]
+
+        raise ValueError('Invalid address pattern')
+
+    @staticmethod
+    def is_encoded_data_valid(encoded_data):
+        if encoded_data is None:
+            return False
+
+        return not isinstance(encoded_data, ModbusIOException) and not isinstance(encoded_data, ExceptionResponse)
+
+    @staticmethod
+    def get_registers_from_encoded_data(encoded_data, function_code):
+        if function_code in (1, 2):
+            encoded_data = encoded_data.bits
+        elif function_code in (3, 4):
+            encoded_data = encoded_data.registers
+        else:
+            raise ValueError(f"Unsupported function code: {function_code}")
+
+        return encoded_data


### PR DESCRIPTION
Example configuration for batch reading:
```json
{
  "tag": "${unitId} - ${type} - ${address}",
  "type": "16int",
  "functionCode": 3,
  "objectsCount": 1,
  "address": "0-10"
}
```

Possible values that can be used for datapoint name forming: `unitId`, `type`, `address`, `functionCode`, `objectsCount`.

Also, `divider` and `multiplier` parameters work as expected.