### PR TITLE
Fixed register allocation for float32/64 in wide range requests

### DIFF
--- a/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
+++ b/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
@@ -143,7 +143,7 @@ class BytesModbusUplinkConverter(ModbusConverter):
             key_name = self.__get_key_name(config, current_address)
             result.append({key_name: decoded_data})
 
-            current_address += 1
+            current_address += config.get('objectsCount', 1)
 
         return result
 

--- a/thingsboard_gateway/connectors/modbus/utils.py
+++ b/thingsboard_gateway/connectors/modbus/utils.py
@@ -16,6 +16,7 @@ from pymodbus import ExceptionResponse
 from pymodbus.exceptions import ModbusIOException
 
 
+
 class Utils:
     @staticmethod
     def is_wide_range_request(address):
@@ -30,7 +31,7 @@ class Utils:
             start_address, end_address = Utils.__parse_wide_range_address(address)
             result = []
 
-            registers_to_read = (end_address - start_address + 1) * objects_count
+            registers_to_read = end_address - start_address + objects_count
             if registers_to_read <= 0:
                 raise ValueError('End address must be greater than start address')
 


### PR DESCRIPTION
When using batch reading like this:
          {
            "tag": "xy_${address}",
            "type": "32float",
            "functionCode": 3,
            "address": "20-22",
            "objectsCount": 2,        
  },

I expect two timeseries keys:
xy_20 and xy_22

but got 
xy_20 , xy_21, xy_22   (where 22 is 0.0)

the same for float64

Should be resolved now.