### PR TITLE
Fixed error with invalid logic using mask in bacnet application section

### DIFF
--- a/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
+++ b/thingsboard_gateway/connectors/bacnet/bacnet_connector.py
@@ -274,8 +274,13 @@ class AsyncBACnetConnector(Thread, Connector):
                     mask)
                 app['mask'] = "24"
                 return True
+
+            elif mask.isdigit() and (0 <= int(mask) <= 32) and app['mask']:
+                self.__log.debug("Using the given mask from config %s", app['mask'])
+                return True
+
             else:
-                IPv4Network(f"{host}/{mask}")
+                IPv4Network(f"{host}/{mask}", strict=False)
                 return True
         except Exception:
             app['mask'] = "24"


### PR DESCRIPTION
1. Fixed error with invalid logic using mask in bacnet application section.
2. Correct logic to validate netmask format.