### PR TITLE
Added Enum support

### DIFF
--- a/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
+++ b/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
@@ -342,8 +342,11 @@ class BytesModbusUplinkConverter(ModbusConverter):
     def _is_enum_value(config):
         return 'variants' in config
 
-    @staticmethod
-    def _process_enum_value(config, decoded_data):
-        enum_key = str(decoded_data)
+    def _process_enum_value(self, config, decoded_data):
+        try:
+            enum_key = str(decoded_data)
 
-        return config['variants'].get(enum_key, decoded_data)
+            return config['variants'].get(enum_key, decoded_data)
+        except Exception as e:
+            self._log.exception(e)
+            return decoded_data


### PR DESCRIPTION
Added Enum support for Modbus connector.

Configuration example:
```json
{
  "tag": "operational_mode",
  "type": "16int",
  "address": 1,
  "objectsCount": 1,
  "functionCode": 3,
  "variants": {
    "1": "Normal Mode",
    "2": "Service Mode",
    "3": "Calibration Mode"
  }
}
```

Result on ThingsBoard platform:
<img width="684" height="58" alt="image" src="https://github.com/user-attachments/assets/ffa252e1-259f-4b2f-8715-b3144ef0b22c" />

Configuration example for coil:
```json
{
  "tag": "relay",
  "type": "bits",
  "address": 1,
  "objectsCount": 1,
  "functionCode": 1,
  "bitTargetType": "int",
  "variants": {
    "0": "OFF",
    "1": "ON"
  }
}
```

Result on ThingsBoard platform:
<img width="979" height="56" alt="image" src="https://github.com/user-attachments/assets/b46b0580-e184-4e00-94fa-52b555131d50" />

Also, the feature works as expected with uplink `RPC to Device`. For example:
```json
"rpc": [
  {
    "tag": "getOperationalMode",
    "type": "16int",
    "address": 1,
    "objectsCount": 1,
    "functionCode": 3,
    "variants": {
      "1": "Normal Mode",
      "2": "Service Mode",
      "3": "Calibration Mode"
    }
  }
]
```

Result on ThingsBoard:
<img width="404" height="219" alt="image" src="https://github.com/user-attachments/assets/6d45dbe9-f0c7-4833-87fb-8c5e3d803989" />
