### PR TITLE
Added ability to use topic as a key name source

### DIFF
--- a/thingsboard_gateway/connectors/mqtt/utils.py
+++ b/thingsboard_gateway/connectors/mqtt/utils.py
@@ -1,0 +1,23 @@
+#     Copyright 2025. ThingsBoard
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from re import search
+
+
+class Utils:
+    @staticmethod
+    def get_value_from_topic(topic, expression):
+        search_result = search(expression, topic)
+        if search_result is not None:
+            return search_result.group(0)


### PR DESCRIPTION
Feature available in advanced configuration mode only. Also, the feature works with JSON and bytes payloads in the same way.

Use the following parameters:
- `"keySource": "topic"`
- `"key": "<regular_expression>"`

Configuration example (for JSON payload):

```json
{
  "topicFilter": "data/",
  "subscriptionQos": 1,
  "converter": {
    "type": "json",
    "deviceInfo": {
      "deviceNameExpressionSource": "constant",
      "deviceNameExpression": "Demo Device",
      "deviceProfileExpressionSource": "constant",
      "deviceProfileExpression": "default"
    },
    "sendDataOnlyOnChange": false,
    "timeout": 60000,
    "attributes": [],
    "timeseries": [
      {
        "type": "double",
        "keySource": "topic",
        "key": "(.+?)(?=/)",
        "value": "${humidity}"
      },
      {
        "type": "string",
        "key": "combine",
        "value": "${temperature}"
      }
    ]
  }
}
```

Result on device:
<img width="605" height="57" alt="image" src="https://github.com/user-attachments/assets/c9cb64ac-a3e1-4ccb-8cd3-f306dd7c3a90" />
