### PR TITLE
Fixed TLS initialization on non-TLS MQTT ports

### DIFF
--- a/thingsboard_gateway/gateway/tb_client.py
+++ b/thingsboard_gateway/gateway/tb_client.py
@@ -258,17 +258,17 @@ class TBClient(threading.Thread):
                                                        daemon=True)
             self._check_cert_thread.start()
 
-        cert_required = CERT_REQUIRED if (self.__ca_cert and
-                                          self.__cert) else ssl.CERT_OPTIONAL if self.__cert else ssl.CERT_NONE
+            cert_required = CERT_REQUIRED if (self.__ca_cert and
+                                              self.__cert) else ssl.CERT_OPTIONAL if self.__cert else ssl.CERT_NONE
 
-        self.client._client.tls_set(ca_certs=self.__ca_cert,
-                                    certfile=self.__cert,
-                                    keyfile=self.__private_key,
-                                    tls_version=ssl.PROTOCOL_TLSv1_2,
-                                    cert_reqs=cert_required,
-                                    ciphers=None)  # noqa pylint: disable=protected-access
-        if credentials.get("insecure", False):
-            self.client._client.tls_insecure_set(True)  # noqa pylint: disable=protected-access
+            self.client._client.tls_set(ca_certs=self.__ca_cert,
+                                        certfile=self.__cert,
+                                        keyfile=self.__private_key,
+                                        tls_version=ssl.PROTOCOL_TLSv1_2,
+                                        cert_reqs=cert_required,
+                                        ciphers=None)  # noqa pylint: disable=protected-access
+            if credentials.get("insecure", False):
+                self.client._client.tls_insecure_set(True)  # noqa pylint: disable=protected-access
         if self.__logger.isEnabledFor(10):
             self.client._client.enable_logger(self.__logger)  # noqa pylint: disable=protected-access
         if self.__proxy_host is not None:


### PR DESCRIPTION
### Fixes #2056 

### Problem:
Gateway may attempt TLS on a non-TLS MQTT port (e.g. 1883), which can cause disconnects / connection resets on some brokers.

### Changes:
- Call tls_set() only when TLS is enabled/configured.
- Call tls_insecure_set(True) only when TLS is enabled.

### Repro:
- Configure gateway to connect to thingsboard.cloud:1883 with access token and without TLS certificates.
- Before: warning about TLS on this port + double connect attempt.
- After: connects successfully on the first attempt without TLS warning.

### Before:
```
2026-02-11 01:22:07.678 - |INFO| - [tb_client.py] - tb_client - __send_connect - 475 - Sending connect to thingsboard.cloud:1883
2026-02-11 01:22:08.329 - |WARNING| - [tb_client.py] - tb_client - connect - 459 - Cannot use TLS connection on this port. Client will try to connect without TLS.
2026-02-11 01:22:08.329 - |INFO| - [tb_client.py] - tb_client - __send_connect - 475 - Sending connect to thingsboard.cloud:1883
```

### After:
```
2026-02-11 01:29:36.440 - |INFO| - [tb_client.py] - tb_client - __send_connect - 475 - Sending connect to thingsboard.cloud:1883
2026-02-11 01:29:37.123 - |INFO| - [tb_client.py] - tb_client - _on_connect - 366 - MQTT client connected to platform thingsboard.cloud: 1883
2026-02-11 01:29:37.123 - |INFO| - [tb_device_mqtt.py] - tb_device_mqtt - _on_connect - 600 - MQTT client <paho.mqtt.client.Client object at 0x77227a939ac0> - Connected!
```