### PR TITLE
Fixed missing string conversion for downlink messages of type json

### DIFF
--- a/thingsboard_gateway/connectors/rest/rest_connector.py
+++ b/thingsboard_gateway/connectors/rest/rest_connector.py
@@ -447,7 +447,7 @@ class RESTConnector(Connector, Thread):
             if content_type == "application/json":
                 if headers:
                     base_params["headers"] = headers
-                base_params["json"] = data
+                base_params["json"] = data if isinstance(data, (dict, list)) else json.loads(data)
                 return base_params
 
             if headers:


### PR DESCRIPTION
REST Connector was missing json.loads if downlink message is not of type dict or list.