### PR TITLE
default port for bacnet; ensure INT for port and mask; fixing default BACnet config

### DIFF
--- a/thingsboard_gateway/config/bacnet.json
+++ b/thingsboard_gateway/config/bacnet.json
@@ -1,9 +1,9 @@
 {
   "application": {
     "objectName": "TB_gateway",
-    "host": "0.0.0.0",
+    "host": "192.168.2.1",
     "port": 47808,
-    "mask": "24",
+    "mask": 24,
     "objectIdentifier": 599,
     "maxApduLengthAccepted": 1476,
     "segmentationSupported": "segmentedBoth",
@@ -28,8 +28,8 @@
       },
       "altResponsesAddresses": [],
       "host": "192.168.2.110",
-      "port": "47808",
-      "mask": "24",
+      "port": 47808,
+      "mask": 24,
       "pollPeriod": 10000,
       "attributes": [
         {

--- a/thingsboard_gateway/connectors/bacnet/entities/device_object_config.py
+++ b/thingsboard_gateway/connectors/bacnet/entities/device_object_config.py
@@ -54,8 +54,7 @@ class DeviceObjectConfig:
             address = address.rstrip('/')
         if 'mask' in config:
             network_mask = config.pop('mask', None)
-            if network_mask:
-                address += '/' + network_mask
-        if 'port' in config:
-            address += ':' + str(config.pop('port', 47808))
+            if network_mask is not None:
+                address += '/' + str(network_mask)
+        address += ':' + str(config.pop('port', 47808))
         config['address'] = address


### PR DESCRIPTION
default BACnet config:
- ensure mask and port are integer
- application IP cannot be 0.0.0.0 when mask is /24, set a plausible IP

bacnet_connector:
- ensure Port and Mask are read as Integer, everything else will throw errors (string doesnt make any sense)
- ensure default BACnet port even when parameter port is completely skipped

bacnet_tests:
- adjusted tests to integer