### PR TITLE
Prevent custom connectors from colliding

### DIFF
--- a/thingsboard_gateway/gateway/tb_gateway_service.py
+++ b/thingsboard_gateway/gateway/tb_gateway_service.py
@@ -910,7 +910,7 @@ class TBGatewayService:
                                       connector_config_from_main['name'])
                             continue
                         else:
-                            self._implemented_connectors[connector_type] = connector_class
+                            self._implemented_connectors[connector_config_from_main['name']] = connector_class
                     elif connector_type == "grpc":
                         if connector_config_from_main.get('key') == "auto":
                             self._generate_persistent_key(connector_config_from_main, connectors_persistent_keys)
@@ -1011,9 +1011,11 @@ class TBGatewayService:
         for connector_type in self.connectors_configs:
             connector_type = connector_type.lower()
             for connector_config in self.connectors_configs[connector_type]:
-                if self._implemented_connectors.get(connector_type) is not None:
+                connector_name = connector_config["name"]
+                connector_class = self._implemented_connectors.get(connector_name)
+                if connector_class is not None:
 
-                    if connector_type == 'grpc' or 'Grpc' in self._implemented_connectors[connector_type].__name__:
+                    if connector_type == 'grpc' or 'Grpc' in self._implemented_connectors[connector_name].__name__:
                         self.__init_and_start_grpc_connector(connector_type, connector_config)
                         return
 
@@ -1049,7 +1051,7 @@ class TBGatewayService:
             available_connector = self.available_connectors_by_id.get(_id)
 
             if available_connector is None or available_connector.is_stopped():
-                connector = self._implemented_connectors[_type](self, deepcopy(configuration), _type)
+                connector = self._implemented_connectors[name](self, deepcopy(configuration), _type)
                 connector.name = name
                 self.available_connectors_by_id[_id] = connector
                 self.available_connectors_by_name[name] = connector


### PR DESCRIPTION
## Context

This PR is linked to the feature request I mentioned in the [discord server](https://discord.com/channels/1458396495610122526/1487081016769380483/1487081016769380483).
When using remote config with multiple custom connectors of the same type, only the last one was ever instantiated. This is because `_implemented_connectors` was keyed by `connector_type`, so each new connector of the same type would silently overwrite the previous entry:
```python
self._implemented_connectors[connector_type] = connector_class
```
I may not have the full context on why it was originally designed this way, happy to get feedback or alternative approaches if there's a reason I'm missing.

## Changes

`_implemented_connectors` is now keyed by connector name instead of connector type, both at registration (`_load_connectors`) and at lookup (`__connect_with_connectors`, `__init_and_start_regular_connector`). Since names are supposedly unique per connector instance, multiple custom connectors of the same type can now coexist.

## Impact

This is a workaround pending proper multi-custom-connector support in the UI. 
This has worked on my part to be able to have 2 different custom connectors at the same time, with 2 different classes. 
Please note that RPC calls have not been tested
Only covers the remote config scenario : for non remote config, it is still possible to have a folder per custom connector.