### PR TITLE
fix: restore missing architecture diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The IoT Gateway is implemented in **Python**, allowing powerful extension and cu
 
 - **Custom connectors** let you interface with new devices or services.
 - **Custom converters** allow transformation of incoming messages to a ThingsBoard-compatible format.
-- The Gateway provides simple integration APIs, and encapsulates common Thingsboard related tasks: device provisioning, local data persistence and delivery, message converters and other.  
+- The Gateway provides simple integration APIs, and encapsulates common ThingsBoard related tasks: device provisioning, local data persistence and delivery, message converters and other.  
 
 > Ideal for edge use cases where flexibility and protocol diversity are key.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Curious how the ThingsBoard IoT Gateway works in action?
 
 ---
 
-[![What is ThingsBoard IoT Gateway?](https://thingsboard.io/images/gateway/python-gateway-animd-ff.svg)](https://thingsboard.io/docs/iot-gateway/what-is-iot-gateway/)
+[![What is ThingsBoard IoT Gateway?](https://img.thingsboard.io/gateway/python-gateway-animd-ff.svg)](https://thingsboard.io/docs/iot-gateway/what-is-iot-gateway/)
 
 ## 🔌 Gateway Features
 


### PR DESCRIPTION
The link to image that showcases tb-gateway's protocol eco-system in the README.md was changed

from `https://thingsboard.io/images/gateway/python-gateway-animd-ff.svg`
to `https://img.thingsboard.io/gateway/python-gateway-animd-ff.svg`