### PR TITLE
Added Modbus function 16 word order regression coverage

### DIFF
--- a/tests/unit/connectors/modbus/test_device_server_side_rpc.py
+++ b/tests/unit/connectors/modbus/test_device_server_side_rpc.py
@@ -14,6 +14,7 @@
 
 from unittest.mock import MagicMock, patch
 from tests.unit.connectors.modbus.modbus_base_test import ServerSideRPCModbusSetUp
+from thingsboard_gateway.connectors.modbus.bytes_modbus_downlink_converter import BytesModbusDownlinkConverter
 from thingsboard_gateway.connectors.modbus.entities.rpc_request import RPCRequest
 
 LOGNAME = "Modbus test"
@@ -121,6 +122,35 @@ class TestDeviceServerSideRPC(ServerSideRPCModbusSetUp):
             self.slave.device_name, 118, {"result": expected}
         )
 
+    async def test_write_device_rpc_function16_respects_configured_word_order(self):
+        self.slave.downlink_converter = BytesModbusDownlinkConverter({}, self.logger)
+
+        content = {'data': {'id': 118, 'method': 'setValue', 'params': 0x12345678},
+                   'device': self.slave.device_name, 'id': 118}
+        rpc_request = RPCRequest(content=content)
+        config = {
+            'type': '32int',
+            'functionCode': 16,
+            'objectsCount': 2,
+            'address': 4
+        }
+
+        test_cases = (
+            ('BIG', [0x1234, 0x5678]),
+            ('LITTLE', [0x5678, 0x1234]),
+        )
+
+        for word_order, expected_registers in test_cases:
+            with self.subTest(word_order=word_order):
+                self.slave.byte_order = 'BIG'
+                self.slave.word_order = word_order
+                self.slave.write.reset_mock()
+
+                out = await self.connector._AsyncModbusConnector__write_rpc_data(self.slave, config, rpc_request)
+
+                assert out == 78
+                self.slave.write.assert_awaited_once_with(16, 4, expected_registers)
+
     async def test_write_device_rpc_no_device_found(self):
         content = {'data': {'id': 115, 'method': 'setValue', 'params': 56},
                    'device': 'Ghost Device', 'id': 115}
@@ -196,4 +226,3 @@ class TestDeviceServerSideRPC(ServerSideRPCModbusSetUp):
         self.gateway.send_rpc_reply.assert_called_once_with(
             self.slave.device_name, 121, {"result": err}
         )
-

--- a/tests/unit/connectors/modbus/test_device_server_side_rpc.py
+++ b/tests/unit/connectors/modbus/test_device_server_side_rpc.py
@@ -12,6 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+import asyncio
+from threading import Thread
 from unittest.mock import MagicMock, patch
 from tests.unit.connectors.modbus.modbus_base_test import ServerSideRPCModbusSetUp
 from thingsboard_gateway.connectors.modbus.bytes_modbus_downlink_converter import BytesModbusDownlinkConverter
@@ -125,31 +127,68 @@ class TestDeviceServerSideRPC(ServerSideRPCModbusSetUp):
     async def test_write_device_rpc_function16_respects_configured_word_order(self):
         self.slave.downlink_converter = BytesModbusDownlinkConverter({}, self.logger)
 
-        content = {'data': {'id': 118, 'method': 'setValue', 'params': 0x12345678},
-                   'device': self.slave.device_name, 'id': 118}
-        rpc_request = RPCRequest(content=content)
-        config = {
-            'type': '32int',
-            'functionCode': 16,
-            'objectsCount': 2,
-            'address': 4
-        }
-
         test_cases = (
-            ('BIG', [0x1234, 0x5678]),
-            ('LITTLE', [0x5678, 0x1234]),
+            ('32int', 0x12345678, 'BIG', [0x1234, 0x5678]),
+            ('32int', 0x12345678, 'LITTLE', [0x5678, 0x1234]),
+            ('32float', 12.34, 'BIG', [0x4145, 0x70A4]),
+            ('32float', 12.34, 'LITTLE', [0x70A4, 0x4145]),
         )
 
-        for word_order, expected_registers in test_cases:
-            with self.subTest(word_order=word_order):
+        for value_type, value, word_order, expected_registers in test_cases:
+            with self.subTest(value_type=value_type, word_order=word_order):
                 self.slave.byte_order = 'BIG'
                 self.slave.word_order = word_order
                 self.slave.write.reset_mock()
+                content = {'data': {'id': 118, 'method': 'setValue', 'params': value},
+                           'device': self.slave.device_name, 'id': 118}
+                rpc_request = RPCRequest(content=content)
+                config = {
+                    'type': value_type,
+                    'functionCode': 16,
+                    'objectsCount': 2,
+                    'address': 4
+                }
 
                 out = await self.connector._AsyncModbusConnector__write_rpc_data(self.slave, config, rpc_request)
 
                 assert out == 78
                 self.slave.write.assert_awaited_once_with(16, 4, expected_registers)
+
+    async def test_device_rpc_function16_uses_configured_word_order(self):
+        self.slave.downlink_converter = BytesModbusDownlinkConverter({}, self.logger)
+        self.slave.rpc_requests_config = [{
+            'tag': 'setValue',
+            'type': '32int',
+            'functionCode': 16,
+            'objectsCount': 2,
+            'address': 4
+        }]
+        self.slave.byte_order = 'BIG'
+        self.slave.word_order = 'LITTLE'
+        content = {'data': {'id': 119, 'method': 'setValue', 'params': 0x12345678},
+                   'device': self.slave.device_name, 'id': 119}
+        rpc_request = RPCRequest(content=content)
+        loop_thread = Thread(target=self.connector.loop.run_forever, daemon=True)
+        loop_thread.start()
+
+        def _create_task_on_connector_loop(coro, args, kwargs):
+            return asyncio.run_coroutine_threadsafe(coro(*args, **kwargs), self.connector.loop)
+
+        try:
+            with patch.object(self.connector,
+                              "_AsyncModbusConnector__create_task",
+                              side_effect=_create_task_on_connector_loop):
+                out = self.connector._AsyncModbusConnector__process_device_rpc_request(rpc_request)
+
+            expected = {"value": 78}
+            assert out == expected
+            self.slave.write.assert_awaited_once_with(16, 4, [0x5678, 0x1234])
+            self.gateway.send_rpc_reply.assert_called_once_with(
+                self.slave.device_name, 119, {"result": expected}
+            )
+        finally:
+            self.connector.loop.call_soon_threadsafe(self.connector.loop.stop)
+            loop_thread.join(timeout=1)
 
     async def test_write_device_rpc_no_device_found(self):
         content = {'data': {'id': 115, 'method': 'setValue', 'params': 56},


### PR DESCRIPTION
## Summary

Adds regression coverage for Modbus RPC writes using function code `16` with multi-register values.

The tests verify that `wordOrder` is preserved when values are encoded for device RPC writes:

- `32int` with `BIG` word order writes `[0x1234, 0x5678]`
- `32int` with `LITTLE` word order writes `[0x5678, 0x1234]`
- `32float` with `BIG` word order writes `[0x4145, 0x70A4]`
- `32float` with `LITTLE` word order writes `[0x70A4, 0x4145]`

The routing-level test also uses the issue-shaped `setValue` configuration with `functionCode: 16`, `objectsCount: 2`, and `address: 4`.

This covers the behavior reported in #1275 without changing runtime logic. Current `master` already produces the expected register order for this path, so the PR documents and protects the behavior with focused unit tests.

## Validation

- `.venv/bin/python -m pytest tests/unit/connectors/modbus/test_device_server_side_rpc.py` - 11 passed
- `.venv/bin/python -m pytest tests/unit/connectors/modbus` - 34 passed
