### PR TITLE
Fixed device duplicating when the device has both ID and IP parameters in the config

### DIFF
--- a/thingsboard_gateway/connectors/bacnet/device.py
+++ b/thingsboard_gateway/connectors/bacnet/device.py
@@ -183,7 +183,6 @@ class Device:
             if device_config.get('deviceId') is not None:
                 if Device.is_device_identifier_match(device_identifier, device_config.get('deviceId')):
                     found_device_configs.append(device_config)
-                else:
                     continue
 
             if Device.is_address_match(apdu_address, device_config.get('address')):


### PR DESCRIPTION
This else statement is creating duplicate local device setups when IP and Bacnet ID are inside the config json