### PR TITLE
Fixed silent disabling remote configuration on self-provisioning gateways

### DIFF
--- a/thingsboard_gateway/tb_utility/tb_gateway_remote_configurator.py
+++ b/thingsboard_gateway/tb_utility/tb_gateway_remote_configurator.py
@@ -138,14 +138,17 @@ class RemoteConfigurator:
         adopted_general_config = {}
         adopted_general_config.update(self.general_configuration)
 
+        # Self-provisioning gateways have no `security` section (credentials come from the
+        # `provisioning` section / provisioned_credentials.json), so it may be absent here.
         security_section = adopted_general_config.get('security')
-        security_type = security_section.get('type', 'accessToken')
-        if security_type == 'accessToken':
-            security_section.pop('clientId', None)
-            security_section.pop('username', None)
-            security_section.pop('password', None)
-        elif security_type == 'usernamePassword':
-            security_section.pop('accessToken', None)
+        if security_section is not None:
+            security_type = security_section.get('type', 'accessToken')
+            if security_type == 'accessToken':
+                security_section.pop('clientId', None)
+                security_section.pop('username', None)
+                security_section.pop('password', None)
+            elif security_type == 'usernamePassword':
+                security_section.pop('accessToken', None)
 
         return {
             'thingsboard': adopted_general_config,
@@ -1052,6 +1055,16 @@ class RemoteConfigurator:
 
     @staticmethod
     def __is_security_match(old_security, new_security):
+        # Self-provisioning gateways have no `security` section (credentials come from the
+        # `provisioning` section / provisioned_credentials.json). When neither side provides a
+        # security section there is nothing to compare, so the connection must not be treated as
+        # changed - otherwise every general_configuration update would force a needless reconnect.
+        # When only one side has a section, it is a genuine change; return without dereferencing None.
+        if not old_security and not new_security:
+            return True
+        if not old_security or not new_security:
+            return False
+
         if new_security.get('type'):
             is_match = RemoteConfigurator.__is_security_match_by_type(old_security, new_security)
         else:


### PR DESCRIPTION
## Problem

When a gateway authenticates via the provisioning section (self-onboarding), remote configuration is silently non-functional: enabling remote logging, changing settings, or adding a connector from the ThingsBoard
gateway dashboard has no effect and nothing is persisted to disk. The only visible hint is an unrelated Unexpected message from topic 'v1/devices/me/attributes' debug line (benign SDK noise — the payload is delivered).

## Root cause

A provisioning gateway has no security section in its configuration — credentials are obtained at runtime and stored separately in provisioned_credentials.json, and TBClient never writes them back into the config.

RemoteConfigurator.__init__ calls _get_general_config_in_local_format(), which assumed a security section always exists:

security_section = adopted_general_config.get('security')   # -> None for a provisioning gateway
security_type = security_section.get('type', 'accessToken') # -> AttributeError: 'NoneType' object has no attribute 'get'

That AttributeError is caught and swallowed by TBGatewayService.__init_remote_configuration, leaving __remote_configurator = None. As a result:
- the config-request consumer thread (_process_config_request) never starts,
- the gateway never sends its current configuration to ThingsBoard,
- every remote update is queued to RECEIVED_UPDATE_QUEUE but never consumed → silently dropped.

A secondary issue affects the same gateways: __is_security_match(None, …) returns False, so once initialized, every general_configuration push forces a full reconnect via _apply_connection_config (consistent with the
reconnect churn reported in #2124).

## Fix

thingsboard_gateway/tb_utility/tb_gateway_remote_configurator.py:

1. _get_general_config_in_local_format — only normalize the security section when it is present, so the method no longer raises for provisioning gateways.
2. __is_security_match — when neither side has a security section, return True (no spurious "connection changed" → no needless reconnect); when only one side has it, return False without dereferencing None.

No public API or config-format changes; behavior is unchanged for gateways that use an explicit security section.

## How to reproduce (before this PR)

1. Configure a gateway with a provisioning section and remoteConfiguration: true, and no security section.
2. Start it; observe Failed to initialize remote configuration and that the gateway never reports its config to TB.
3. Add a connector from the gateway dashboard → it is never written to disk / never loaded.

## Testing

- RemoteConfigurator constructs successfully with a provisioning config; the consumer thread starts (previously raised AttributeError).
- Driving the full pipeline, a remote-added Modbus connector now persists both its connector file and tb_gateway.json.
- __is_security_match truth table verified: (None, {})→True, ({}, {})→True, (None, token)→False, (tokenA, tokenA)→True, (tokenA, tokenB)→False.
- Verified against the real thingsboard/tb-gateway:3.8.2 image: stock image raises AttributeError; with the guard it returns cleanly with no spurious security key.

## Compatibility

Backward compatible. Gateways using accessToken / usernamePassword / tlsAccessToken are unaffected; only the previously-crashing no-security (provisioning) path changes.

Closes #2061.