### PR TITLE
Fix coil decoding order

### DIFF
--- a/tests/unit/converters/modbus/test_bytes_modbus_uplink_converter.py
+++ b/tests/unit/converters/modbus/test_bytes_modbus_uplink_converter.py
@@ -214,6 +214,22 @@ class ModbusConverterTests(BaseUnitTest):
         result = converter.convert(test_modbus_convert_config, test_modbus_body_to_convert)
         self.assertDictEqual(result, test_modbus_result)
 
+    def test_decode_coils_preserves_leading_bit_order(self):
+        converter = object.__new__(BytesModbusUplinkConverter)
+        config = {
+            "functionCode": 1,
+            "type": "bits",
+            "objectsCount": 2,
+        }
+        encoded_data = [True, False, False, False, False, False, False, False]
+        result = converter.decode_data(
+            encoded_data,
+            config,
+            Endian.LITTLE,
+            Endian.BIG,
+        )
+        self.assertEqual([True, False], result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
+++ b/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
@@ -281,7 +281,7 @@ class BytesModbusUplinkConverter(ModbusConverter):
             decoded = decoder_functions[lower_type]()
             decoded_lastbyte = decoder_functions[lower_type]()
             decoded += decoded_lastbyte
-            decoded = decoded[len(decoded)-objects_count:]
+            decoded = decoded[:objects_count]
 
         elif lower_type == "string":
             decoded = decoder_functions[lower_type](objects_count * 2)


### PR DESCRIPTION
## SUMMARY
- preserve the leading coil bits when limiting decoded values to 'objectsCount'
- add a regression test for the reported bit-order case

Fixes #2146

## TESTING
- added 'test_decode_coils_preserves_leading_bit_order'
- not run locally; changes were made through the GitHub web editor