### PR TITLE
Unpin Python "packaging"

### DIFF
--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,5 +1,5 @@
 setuptools
-packaging==23.1
+packaging
 jsonpath-rw
 regex
 pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
-packaging==23.1
+packaging
 jsonpath-rw
 regex
 pip

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         'cachetools',
         'tb-paho-mqtt-client>=2.1.2',
         'tb-mqtt-client==1.13.13',
-        'packaging==23.1',
+        'packaging',
         'service-identity',
         'psutil',
         'PySocks',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 twine
-packaging==23.1
+packaging
 jsonpath-rw
 regex
 pip


### PR DESCRIPTION
Do not pin the Python library "packaging" to an old version anymore. Newer versions do not seem to contain any incompatibilities.

Pinning also blocks thingsboard-gateway from using the system-wide installed packaging library. This is relevant for e.g. embedded platforms, natively installing thingsboard-gateway and its dependencies.

This fixes the following error message during startup:
```
...
Mar 13 15:35:24 mydevice python3[695]: ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
Mar 13 15:35:24 mydevice python3[695]: thingsboard-gateway 3.8.3 requires packaging==23.1, but you have packaging 26.0 which is incompatible.
...
```