### PR TITLE
Fixed boolean type conversion

### DIFF
--- a/thingsboard_gateway/connectors/knx/knx_uplink_converter.py
+++ b/thingsboard_gateway/connectors/knx/knx_uplink_converter.py
@@ -17,6 +17,7 @@ from thingsboard_gateway.gateway.entities.converted_data import ConvertedData
 from thingsboard_gateway.gateway.entities.report_strategy_config import ReportStrategyConfig
 from thingsboard_gateway.gateway.statistics.statistics_service import StatisticsService
 from thingsboard_gateway.tb_utility.tb_utility import TBUtility
+
 from xknx.dpt.dpt_1 import Bool as knx_Bool
 
 

--- a/thingsboard_gateway/connectors/knx/knx_uplink_converter.py
+++ b/thingsboard_gateway/connectors/knx/knx_uplink_converter.py
@@ -17,6 +17,7 @@ from thingsboard_gateway.gateway.entities.converted_data import ConvertedData
 from thingsboard_gateway.gateway.entities.report_strategy_config import ReportStrategyConfig
 from thingsboard_gateway.gateway.statistics.statistics_service import StatisticsService
 from thingsboard_gateway.tb_utility.tb_utility import TBUtility
+from xknx.dpt.dpt_1 import Bool as knx_Bool
 
 
 class KNXUplinkConverter(KNXConverter):
@@ -31,6 +32,7 @@ class KNXUplinkConverter(KNXConverter):
 
         converted_data = ConvertedData(device_name=device_name, device_type=device_type)
 
+
         device_report_strategy = self._get_device_report_strategy(self.__config.get('reportStrategy'),
                                                                   device_name)
 
@@ -38,6 +40,9 @@ class KNXUplinkConverter(KNXConverter):
             for config in self.__config.get(section, []):
                 try:
                     converted_value = data.get(config.get('groupAddress'))['response']
+                    if isinstance(converted_value, knx_Bool):
+                        converted_value = converted_value.value
+
                     if converted_value is not None:
                         datapoint_key = TBUtility.convert_key_to_datapoint_key(config['key'],
                                                                                device_report_strategy,


### PR DESCRIPTION
Fixes #2153

### Problem
When polling 1-bit DPT group addresses, the `xknx` library returns custom Enum objects (`Bool`). This caused the gateway to crash with `TypeError: Object of type Switch/Bool is not JSON serializable`.

### Solution
In `knx_uplink_converter.py`:
- Extract primitive Python values using the `.value` attribute for `xknx` DPT objects.

### Testing
Tested on `tb-gateway:3.8-stable`. Telemetry now correctly serializes to native Python `bool` (`True`/`False`) without errors.