### PR TITLE
Fixed bulk SNMP operations by making the protocol version configurable

### DIFF
--- a/thingsboard_gateway/config/snmp.json
+++ b/thingsboard_gateway/config/snmp.json
@@ -7,6 +7,7 @@
       "port": 161,
       "pollPeriod": 5000,
       "community": "public",
+      "version": "v2c",
       "attributes": [
         {
           "key": "ReceivedFromGet",
@@ -118,6 +119,7 @@
       "ip": "127.0.0.1",
       "pollPeriod": 5000,
       "community": "public",
+      "version": "v2c",
       "converter": "CustomSNMPConverter",
       "attributes": [
         {

--- a/thingsboard_gateway/connectors/snmp/snmp_connector.py
+++ b/thingsboard_gateway/connectors/snmp/snmp_connector.py
@@ -45,6 +45,12 @@ if installation_required:
 from puresnmp import Client, credentials, PyWrapper
 from puresnmp.exc import Timeout as SNMPTimeoutException
 
+DEFAULT_SNMP_VERSION = 'v2c'
+SNMP_CREDENTIALS_BY_VERSION = {
+    'v1': credentials.V1,
+    'v2c': credentials.V2C,
+}
+
 
 class SNMPConnector(Connector, Thread):
     def __init__(self, gateway, config, connector_type):
@@ -170,7 +176,7 @@ class SNMPConnector(Connector, Thread):
     async def __process_methods(self, method, common_parameters, datatype_config):
         client = Client(ip=common_parameters['ip'],
                         port=common_parameters['port'],
-                        credentials=credentials.V1(common_parameters['community']))
+                        credentials=self.__get_credentials(common_parameters))
         client.configure(timeout=common_parameters['timeout'])
         client = PyWrapper(client)
 
@@ -247,12 +253,22 @@ class SNMPConnector(Connector, Thread):
         except Exception as e:
             self._log.exception(e)
 
+    def __get_credentials(self, common_parameters):
+        version = common_parameters.get("version", DEFAULT_SNMP_VERSION)
+        credentials_type = SNMP_CREDENTIALS_BY_VERSION.get(version)
+        if credentials_type is None:
+            self._log.warning("Unknown SNMP version: %r, falling back to %r. Supported versions: %s",
+                              version, DEFAULT_SNMP_VERSION, ", ".join(SNMP_CREDENTIALS_BY_VERSION))
+            credentials_type = SNMP_CREDENTIALS_BY_VERSION[DEFAULT_SNMP_VERSION]
+        return credentials_type(common_parameters["community"])
+
     @staticmethod
     def __get_common_parameters(device):
         return {"ip": gethostbyname(device["ip"]),
                 "port": device.get("port", 161),
                 "timeout": device.get("timeout", 6),
                 "community": device["community"],
+                "version": str(device.get("version", DEFAULT_SNMP_VERSION)).lower(),
                 }
 
     def on_attributes_update(self, content):


### PR DESCRIPTION
Closes #2150

## Problem

`SNMPConnector` hardcodes `credentials.V1`, so every request goes out with the SNMP version field set to `0` (SNMPv1):

https://github.com/thingsboard/thingsboard-gateway/blob/master/thingsboard_gateway/connectors/snmp/snmp_connector.py#L171-L173

GETBULK was introduced in SNMPv2c. Carried inside an SNMPv1 message it is discarded by the agent, and the client times out — the `TimeoutError` reported in #2150.

This is not limited to `bulkwalk`. Three of the eleven advertised methods are built on GETBULK and are therefore unusable:

- `bulkget`
- `bulkwalk`
- `bulktable`

In `puresnmp`, `V2C` subclasses `V1` and overrides only `mpm` (`0` → `1`), which is the version field in the packet. The credential class alone decides whether bulk operations can work.

## Reproduction

Against a local `snmpsim` agent (community `public`), walking `1.3.6.1.2.1.2.2.1.2` (3 entries):

| credentials | `get` | `bulkwalk` |
| --- | --- | --- |
| `V1` (current) | OK | `Timeout: 3 second timeout exceeded on UDP transport.` |
| `V2C` | OK | OK — 3 rows |

## Change

Adds an optional per-device `version` key accepting `v1` or `v2c`, defaulting to `v2c`. SNMPv1-only agents stay reachable by setting it explicitly. An unknown value logs a warning and falls back to the default rather than breaking the poll.

The key is also added to the shipped `config/snmp.json` example so it is discoverable.

## Verification

Exercised through `SNMPConnector.__process_methods` against the same agent:

| device config | resolved version | method | result |
| --- | --- | --- | --- |
| no `version` key | `v2c` | `bulkwalk` | OK — 3 rows |
| `"version": "v1"` | `v1` | `bulkwalk` | times out (previous behaviour, now opt-in) |
| `"version": "v1"` | `v1` | `get` | OK — no regression for v1-only agents |
| `"version": "V2C"` | `v2c` | `bulkwalk` | OK — case normalised |
| `"version": "v9"` | falls back | `bulkwalk` | OK — warning logged |

## On the default value

I defaulted to `v2c` because the connector advertises bulk methods that cannot work under v1, and `puresnmp` itself emits `UserWarning: Experimental SNMPv1 support`. This does change behaviour for anyone relying on the implicit v1, so if you would rather keep `v1` as the default and have users opt into `v2c`, say the word and I will flip it — the change is one constant.

## Notes

- No tests added: there is currently no SNMP coverage under `tests/`. Happy to add unit tests for the version resolution if you want them in this PR.
- Out of scope, but noticed while working on this: `config/snmp.json` shows a per-datapoint `"community"` override, while the connector only reads `device["community"]`. I left it alone to keep this change focused.
- `v3` is not included since it needs auth/priv parameters and a wider config surface.
