### PR TITLE
Fixed OCPP connector failing to load on ocpp 2.x

### DIFF
--- a/thingsboard_gateway/connectors/ocpp/charge_point.py
+++ b/thingsboard_gateway/connectors/ocpp/charge_point.py
@@ -61,7 +61,7 @@ class ChargePoint(CP):
         self._stopped = True
         return await self._connection.close()
 
-    @on(Action.BootNotification)
+    @on(Action.boot_notification)
     def on_boot_notification(self, charge_point_vendor: str, charge_point_model: str, **kwargs):
         self._profile = {
             'Vendor': charge_point_vendor,
@@ -71,37 +71,37 @@ class ChargePoint(CP):
         self.type = self._uplink_converter.get_device_type(self._profile)
 
         self._callback((self._uplink_converter,
-                        {'deviceName': self.name, 'deviceType': self.type, 'messageType': Action.MeterValues,
+                        {'deviceName': self.name, 'deviceType': self.type, 'messageType': Action.meter_values,
                          'profile': self._profile},
                         {'Vendor': charge_point_vendor, 'Model': charge_point_model, **kwargs}))
 
-        return call_result.BootNotificationPayload(
+        return call_result.BootNotification(
             current_time=datetime.utcnow().isoformat(),
             interval=10,
             status=RegistrationStatus.accepted
         )
 
-    @on(Action.Authorize)
+    @on(Action.authorize)
     def on_authorize(self, id_tag: str, **kwargs):
         if self.authorized:
-            return call_result.AuthorizePayload(id_tag_info={'status': 'Accepted'})
+            return call_result.Authorize(id_tag_info={'status': 'Accepted'})
 
-        return call_result.AuthorizePayload(id_tag_info={'status': 'Not authorized'})
+        return call_result.Authorize(id_tag_info={'status': 'Not authorized'})
 
-    @on(Action.Heartbeat)
+    @on(Action.heartbeat)
     def on_heartbeat(self):
-        return call_result.HeartbeatPayload(
+        return call_result.Heartbeat(
             current_time=datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S') + "Z"
         )
 
-    @on(Action.MeterValues)
+    @on(Action.meter_values)
     def on_meter_values(self, **kwargs):
         self._callback((self._uplink_converter,
-                        {'deviceName': self.name, 'deviceType': self.type, 'messageType': Action.MeterValues,
+                        {'deviceName': self.name, 'deviceType': self.type, 'messageType': Action.meter_values,
                          'profile': self._profile}, kwargs))
-        return call_result.MeterValuesPayload()
+        return call_result.MeterValues()
 
-    @on(Action.DataTransfer)
+    @on(Action.data_transfer)
     def on_data_transfer(self, **kwargs):
         for (key, value) in kwargs.items():
             try:
@@ -110,6 +110,6 @@ class ChargePoint(CP):
                 continue
 
         self._callback((self._uplink_converter,
-                        {'deviceName': self.name, 'deviceType': self.type, 'messageType': Action.DataTransfer,
+                        {'deviceName': self.name, 'deviceType': self.type, 'messageType': Action.data_transfer,
                          'profile': self._profile}, kwargs))
-        return call_result.DataTransferPayload(status=DataTransferStatus.accepted)
+        return call_result.DataTransfer(status=DataTransferStatus.accepted)

--- a/thingsboard_gateway/connectors/ocpp/ocpp_connector.py
+++ b/thingsboard_gateway/connectors/ocpp/ocpp_connector.py
@@ -295,7 +295,7 @@ class OcppConnector(Connector, Thread):
                         data = attribute_update_config["valueExpression"] \
                             .replace("${attributeKey}", str(attr_key)) \
                             .replace("${attributeValue}", str(attr_value))
-                        request = call.DataTransferPayload('1', data=data)
+                        request = call.DataTransfer('1', data=data)
 
                         task = self.__loop.create_task(self._send_request(charge_point, request))
                         while not task.done():
@@ -337,7 +337,7 @@ class OcppConnector(Connector, Thread):
         for (tag, value) in zip(data_to_send_tags, data_to_send_values):
             data_to_send = data_to_send.replace('${' + tag + '}', dumps(value))
 
-        request = call.DataTransferPayload('1', data=data_to_send)
+        request = call.DataTransfer('1', data=data_to_send)
 
         task = self.__loop.create_task(
             self._send_request(charge_point, request))


### PR DESCRIPTION
Closes #1908

## Problem

The OCPP connector cannot be imported at all on current versions of the `ocpp` library:

```
File "/thingsboard_gateway/connectors/ocpp/charge_point.py", line 64, in ChargePoint
    @on(Action.BootNotification)
AttributeError: type object 'Action' has no attribute 'BootNotification'.
Did you mean: 'boot_notification'?
```

`ocpp` 1.0 deprecated two things and 2.0 removed them:

- the PascalCase `Action` enum members, in favour of snake_case
- the `Payload` suffix on `call` / `call_result` classes

The 1.0 source says so explicitly:

> Action enum contains deprecated members and will be removed in the next major release, please use snake case members.

`requirements-full.txt` lists `ocpp` unpinned, so any fresh install resolves to 2.x and the connector is dead on arrival. `TBModuleLoader` reports the import failure and no OCPP device can connect.

## Change

Renamed 16 references across two files to the current API:

| before | after |
| --- | --- |
| `Action.BootNotification` | `Action.boot_notification` |
| `call_result.BootNotificationPayload` | `call_result.BootNotification` |
| `call.DataTransferPayload` | `call.DataTransfer` |

…and the same for `Authorize`, `Heartbeat`, `MeterValues`, `DataTransfer`.

## This does not drop ocpp 1.x support

Both spellings exist in 1.0, so the new names resolve there too. No version pin is needed and no existing install breaks.

The enum values are also identical, so nothing changes at runtime:

```python
>>> Action.meter_values.value        # ocpp 1.0.0 and 2.1.0
'MeterValues'
```

That matters because `Action.meter_values` is passed through as `messageType` to the uplink converter — the converter still receives the same string it did before.

## Verification

Imported `charge_point` and `ocpp_connector` against three library versions:

| ocpp | before | after |
| --- | --- | --- |
| 1.0.0 | imports | imports |
| 2.0.0 | `AttributeError` | imports |
| 2.1.0 | `AttributeError` | imports |

So the change strictly widens the supported range rather than shifting it.

## Notes

- No tests added: there is no OCPP coverage under `tests/` today. Happy to add an import smoke test if you would like one in this PR.
- I did not pin `ocpp` in `requirements-full.txt`, since the connector now works on both major versions. Let me know if you would rather have a lower bound recorded there anyway.
- Only the names the connector actually uses were touched. I did not sweep the rest of the OCPP surface for other deprecations.
