### PR TITLE
Fixed partial records handling in file storage

### DIFF
--- a/tests/unit/service/test_file_event_storage_reader.py
+++ b/tests/unit/service/test_file_event_storage_reader.py
@@ -1,0 +1,138 @@
+#     Copyright 2026. ThingsBoard
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from base64 import b64encode
+from json import dump, dumps
+from logging import getLogger
+from os import sep
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from thingsboard_gateway.storage.file.event_storage_files import EventStorageFiles
+from thingsboard_gateway.storage.file.event_storage_reader import EventStorageReader
+from thingsboard_gateway.storage.file.file_event_storage_settings import FileEventStorageSettings
+
+
+LOG = getLogger("TEST")
+LOG.trace = LOG.debug
+
+
+class TestFileEventStorageReader(TestCase):
+    DATA_FILE = "data_test.txt"
+    STATE_FILE = "state_file.txt"
+
+    def setUp(self):
+        self.temporary_directory = TemporaryDirectory()
+        self.data_directory = Path(self.temporary_directory.name)
+        self.data_file = self.data_directory / self.DATA_FILE
+        self.state_file = self.data_directory / self.STATE_FILE
+        with self.state_file.open("w", encoding="utf-8") as state_file:
+            dump({"position": 0, "file": self.DATA_FILE}, state_file)
+        self.reader = None
+
+    def tearDown(self):
+        if self.reader is not None and self.reader.buffered_reader is not None:
+            self.reader.buffered_reader.close()
+        self.temporary_directory.cleanup()
+
+    def _create_reader(self, additional_data_files=None):
+        data_files = {self.DATA_FILE: False}
+        if additional_data_files:
+            data_files.update({file_name: False for file_name in additional_data_files})
+        files = EventStorageFiles(self.STATE_FILE, data_files)
+        settings = FileEventStorageSettings({
+            "data_folder_path": str(self.data_directory) + sep,
+            "max_records_per_file": 100,
+            "max_read_records_count": 100,
+        })
+        self.reader = EventStorageReader(files, settings, LOG)
+        return self.reader
+
+    @staticmethod
+    def _event(timestamp):
+        event = {
+            "deviceName": "Test Device",
+            "telemetry": [{"ts": timestamp, "values": {f"key_{index}": index for index in range(100)}}],
+        }
+        return dumps(event, separators=(",", ":"))
+
+    @classmethod
+    def _encoded_event(cls, timestamp):
+        return b64encode(cls._event(timestamp).encode("utf-8"))
+
+    def test_waits_for_newline_before_returning_first_record(self):
+        encoded_event = self._encoded_event(1)
+        partial_length = 64
+        self.data_file.write_bytes(encoded_event[:partial_length])
+        reader = self._create_reader()
+
+        self.assertListEqual(reader.read(), [])
+
+        with self.data_file.open("ab") as data_file:
+            data_file.write(encoded_event[partial_length:] + b"\n")
+
+        self.assertListEqual(reader.read(), [self._event(1)])
+
+    def test_does_not_skip_partial_record_when_next_file_exists(self):
+        encoded_event = self._encoded_event(1)
+        next_data_file = "data_zzzz.txt"
+        self.data_file.write_bytes(encoded_event[:64])
+        (self.data_directory / next_data_file).write_bytes(self._encoded_event(2) + b"\n")
+        reader = self._create_reader([next_data_file])
+
+        self.assertListEqual(reader.read(), [])
+        self.assertTrue(self.data_file.exists())
+
+        with self.data_file.open("ab") as data_file:
+            data_file.write(encoded_event[64:] + b"\n")
+
+        self.assertListEqual(reader.read(), [self._event(1), self._event(2)])
+
+    def test_preserves_order_when_complete_record_precedes_partial_record(self):
+        first_event = self._encoded_event(1)
+        second_event = self._encoded_event(2)
+        partial_length = 64
+        self.data_file.write_bytes(first_event + b"\n" + second_event[:partial_length])
+        reader = self._create_reader()
+
+        first_batch = reader.read()
+        reader.discard_batch()
+        with self.data_file.open("ab") as data_file:
+            data_file.write(second_event[partial_length:] + b"\n")
+        second_batch = reader.read()
+
+        self.assertEqual(1, len(first_batch))
+        self.assertEqual(1, len(second_batch))
+        self.assertIn('"ts":1', first_batch[0])
+        self.assertIn('"ts":2', second_batch[0])
+
+    def test_preserves_partial_record_after_reader_restart(self):
+        first_event = self._encoded_event(1)
+        second_event = self._encoded_event(2)
+        partial_length = 64
+        self.data_file.write_bytes(first_event + b"\n" + second_event[:partial_length])
+        reader = self._create_reader()
+
+        self.assertListEqual(reader.read(), [self._event(1)])
+        reader.discard_batch()
+        reader.buffered_reader.close()
+
+        restarted_reader = self._create_reader()
+        self.assertListEqual(restarted_reader.read(), [])
+
+        with self.data_file.open("ab") as data_file:
+            data_file.write(second_event[partial_length:] + b"\n")
+
+        self.assertListEqual(restarted_reader.read(), [self._event(2)])

--- a/thingsboard_gateway/storage/file/event_storage_reader.py
+++ b/thingsboard_gateway/storage/file/event_storage_reader.py
@@ -51,8 +51,12 @@ class EventStorageReader:
                 current_line_in_file = self.new_pos.get_line()
                 self.buffered_reader = self.get_or_init_buffered_reader(self.new_pos)
                 if self.buffered_reader is not None:
+                    line_start_offset = self.buffered_reader.tell()
                     line = self.buffered_reader.readline()
                     while line != b'':
+                        if not line.endswith(b'\n'):
+                            self.buffered_reader.seek(line_start_offset)
+                            return self.current_batch
                         try:
                             self.current_batch.append(b64decode(line).decode("utf-8"))
                             records_to_read -= 1
@@ -68,6 +72,7 @@ class EventStorageReader:
                         finally:
                             current_line_in_file += 1
                             if records_to_read > 0:
+                                line_start_offset = self.buffered_reader.tell()
                                 line = self.buffered_reader.readline()
                         self.new_pos.set_line(current_line_in_file)
                         if records_to_read == 0:
@@ -132,12 +137,10 @@ class EventStorageReader:
                 new_file_to_read_path = self.settings.get_data_folder_path() + pointer.get_file()
                 self.buffered_reader = BufferedReader(FileIO(new_file_to_read_path, 'r'))
                 lines_to_skip = pointer.get_line()
-                if lines_to_skip > 0:
-                    while self.buffered_reader.readline() is not None:
-                        if lines_to_skip > 0:
-                            lines_to_skip -= 1
-                        else:
-                            break
+                while lines_to_skip > 0:
+                    if self.buffered_reader.readline() == b'':
+                        break
+                    lines_to_skip -= 1
 
             return self.buffered_reader
 


### PR DESCRIPTION
Fixes #2167

## Problem

File storage writes each message as a Base64-encoded JSON record terminated by a newline. The writer and reader operate concurrently, but `EventStorageReader` accepted every non-empty result from `readline()` as a complete record.

At EOF, `readline()` may return the bytes currently available while the writer is still appending the record. A partial Base64 payload can decode successfully into truncated JSON. That invalid message may then remain in the current batch and be retried indefinitely because it is never acknowledged as published.

A related recovery bug made a newline guard insufficient on its own: restoring a non-zero state position called `readline()` once more after all acknowledged lines had already been skipped. After a restart, that consumed the first pending record (or its currently available prefix).

## Changes

- Record the byte offset before each `readline()` call.
- Only consume records terminated by `\n` (`\r\n` remains accepted).
- Seek back to the saved offset and return the completed part of the batch when the current line is still being written.
- Stop before file-transition logic so a partial current file is not removed when a newer file exists.
- Restore the state pointer by reading exactly the acknowledged number of lines, without consuming the next record.
- Add deterministic unit coverage for partial reads, ordering, file transitions, and restart recovery.

No configuration format or public API changes.

## Verification

The regression tests fail against the previous reader behavior and pass with this change.

```text
python -m unittest tests.unit.service.test_file_event_storage_reader -v
Ran 4 tests ... OK
```

The same four tests passed on Python 3.10, 3.11, 3.12, and 3.13. I also ran:

- the existing file-storage test and adjacent timestamp resolver tests (9 tests, all passing);
- `compileall` for the changed storage package and test;
- `pip check` and `git diff --check`;
- a build using the repository's official `docker/Dockerfile`.

In an isolated Docker deployment based on Gateway 3.8.4, the guarded reader processed hundreds of complete stored records with no JSON decode errors, storage-processing errors, duplicates, or gateway restarts.
